### PR TITLE
Added .club domains for dev and test

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -20,12 +20,12 @@ resource "aws_cloudfront_origin_access_identity" "app" {
   comment = local.app_name
 }
 
-# data "aws_acm_certificate" "domain" {
-#   count    = local.has_domain ? 1 : 0
-#   provider = aws.us-east-1
-#   domain   = var.domain
-#   statuses = ["ISSUED"]
-# }
+data "aws_acm_certificate" "domain" {
+  count    = local.has_domain ? 1 : 0
+  provider = aws.us-east-1
+  domain   = var.domain
+  statuses = ["ISSUED"]
+}
 
 
 
@@ -48,9 +48,12 @@ resource "aws_cloudfront_function" "request" {
 
 resource "aws_cloudfront_distribution" "app" {
   comment = local.app_name
+  // dev.ien.freshworks.club
+  // work on condition 
+  //aliases = var.target_env  ? [var.domain] : [] # Production DNS names to be populated
 
-  # aliases = local.fw_domain ? [var.domain] : [] # Production DNS names to be populated
-  aliases = []
+  aliases = local.fw_domain ? [var.domain] : []
+
   origin {
     domain_name = aws_s3_bucket.app.bucket_regional_domain_name
     origin_id   = local.s3_origin_id
@@ -158,17 +161,17 @@ resource "aws_cloudfront_distribution" "app" {
     }
   }
 
-  # viewer_certificate {
-  #   cloudfront_default_certificate = local.has_domain ? false : true
-
-  #   acm_certificate_arn      = local.has_domain ? data.aws_acm_certificate.domain[0].arn : null
-  #   minimum_protocol_version = local.has_domain ? "TLSv1.2_2019" : null
-  #   ssl_support_method       = local.has_domain ? "sni-only" : null
-  # }
-
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = local.has_domain ? false : true
+
+    acm_certificate_arn      = local.has_domain ? data.aws_acm_certificate.domain[0].arn : null
+    minimum_protocol_version = local.has_domain ? "TLSv1.2_2019" : null
+    ssl_support_method       = local.has_domain ? "sni-only" : null
   }
+
+  # viewer_certificate {
+  #   cloudfront_default_certificate = true
+  # }
 
 
   custom_error_response {

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -48,10 +48,7 @@ resource "aws_cloudfront_function" "request" {
 
 resource "aws_cloudfront_distribution" "app" {
   comment = local.app_name
-  // dev.ien.freshworks.club
-  // work on condition 
-  //aliases = var.target_env  ? [var.domain] : [] # Production DNS names to be populated
-
+  
   aliases = local.fw_domain ? [var.domain] : []
 
   origin {
@@ -169,9 +166,6 @@ resource "aws_cloudfront_distribution" "app" {
     ssl_support_method       = local.has_domain ? "sni-only" : null
   }
 
-  # viewer_certificate {
-  #   cloudfront_default_certificate = true
-  # }
 
 
   custom_error_response {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,4 +36,5 @@ locals {
   db_name = "${local.namespace}-db"
 
   has_domain = var.domain != ""
+  fw_domain  = length(regexall("freshworks", var.domain)) > 0
 }


### PR DESCRIPTION
This links the cloud front distributions for dev/test to freshworks.club domains and adds ssl certs. The DNS records for the .club domain are on Freshwork's aws and the certifcates were created manually in LZ2. 

Note: I've already applied these both to dev and test. 

Big thanks to Vyas for helping me get this to work. 