### PR TITLE
show word Today for competition duration being added on current date

### DIFF
--- a/apps/web/src/services/date-utils.ts
+++ b/apps/web/src/services/date-utils.ts
@@ -20,5 +20,13 @@ dayjs.extend(duration);
 dayjs.extend(relativeTime, { thresholds });
 
 export const getHumanizedDuration = (start: dayjs.ConfigType, end?: dayjs.ConfigType): string => {
+  // since we don't keep track of time, start_date from the DB gets set to 00:00:00:00
+  // so anything less than a day will take the current locale time and compare it to start_date
+  // ex if new status is added at 12pm locale time,
+  // it will be a 12hr duration when compared to start_date from DB
+  if (start === dayjs().format('YYYY-MM-DD')) {
+    return 'today';
+  }
+
   return dayjs.duration(dayjs(start).diff(end || new Date())).humanize();
 };


### PR DESCRIPTION
this seems more like a quick fix to me, I'm not sure at the moment what else to do with this.  I left a comment above the change, but it's basically comparing the start_date from the last milestone to the current date, excluding time values