### PR TITLE
fix for tab requests using previous skip value

### DIFF
--- a/apps/web/src/pages/applicants.tsx
+++ b/apps/web/src/pages/applicants.tsx
@@ -92,6 +92,7 @@ const Applicants = () => {
   };
 
   const handleTabChange = (index: number) => {
+    setPageIndex(1);
     changeRoute(name, index ? index + 10000 : 0);
   };
 


### PR DESCRIPTION
when using page options in a tab, ex All and setting items per page to anything besides default, going to last page then switching tabs, the requests would include the amount skipped from the previous request, skipping over items inside Intake tab, so I just set the page Index back to 1 when changing tabs