### PR TITLE
IEN 707 - reorder max date check for data extract

### DIFF
--- a/apps/web/src/components/reporting/DataExtractReport.tsx
+++ b/apps/web/src/components/reporting/DataExtractReport.tsx
@@ -81,7 +81,7 @@ export const DataExtractReport = () => {
                   label='End Date'
                   format='yyyy-MM-dd'
                   min={dayjs(values.from || MIN_DATE).toDate()}
-                  max={dayjs(values.to || getMaxDate()).toDate()}
+                  max={dayjs(getMaxDate() || values.to).toDate()}
                   validate={(val: string) => validateDate(val)}
                 />
               </span>

--- a/apps/web/src/components/reporting/DataExtractReport.tsx
+++ b/apps/web/src/components/reporting/DataExtractReport.tsx
@@ -81,7 +81,7 @@ export const DataExtractReport = () => {
                   label='End Date'
                   format='yyyy-MM-dd'
                   min={dayjs(values.from || MIN_DATE).toDate()}
-                  max={dayjs(getMaxDate() || values.to).toDate()}
+                  max={dayjs(getMaxDate()).toDate()}
                   validate={(val: string) => validateDate(val)}
                 />
               </span>


### PR DESCRIPTION
re ordered the max date check for the datapicker on Data Extract, was previously giving the current value picked priority