### PR TITLE
IEN-798 - migration to remove old unused tables

### DIFF
--- a/apps/api/src/migration/1676577091787-RemoveOldUnusedTables.ts
+++ b/apps/api/src/migration/1676577091787-RemoveOldUnusedTables.ts
@@ -5,10 +5,10 @@ export class RemoveOldUnusedTables1676577091787 implements MigrationInterface {
     await queryRunner.query(`
       DROP TABLE IF EXISTS form;
       DROP TABLE IF EXISTS submission;
-      DROP TABLE IF EXISTS applicant_status;
-      DROP TABLE IF EXISTS applicants;
-      DROP TABLE IF EXISTS applicant_status_audit;
-      DROP TABLE IF EXISTS applicant_audit;
+      DROP TABLE IF EXISTS applicant_status CASCADE;
+      DROP TABLE IF EXISTS applicants CASCADE;
+      DROP TABLE IF EXISTS applicant_status_audit CASCADE;
+      DROP TABLE IF EXISTS applicant_audit CASCADE;
     `);
   }
 

--- a/apps/api/src/migration/1676577091787-RemoveOldUnusedTables.ts
+++ b/apps/api/src/migration/1676577091787-RemoveOldUnusedTables.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveOldUnusedTables1676577091787 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP TABLE IF EXISTS form;
+      DROP TABLE IF EXISTS submission;
+      DROP TABLE IF EXISTS applicant_status;
+      DROP TABLE IF EXISTS applicants;
+      DROP TABLE IF EXISTS applicant_status_audit;
+      DROP TABLE IF EXISTS applicant_audit;
+    `);
+  }
+
+  public async down(): Promise<void> {
+    // no rollback with this migration
+  }
+}


### PR DESCRIPTION
removes unused tables created during initial project setup

Note: only `form` and `submission` were found in dev, test and prod.  The other applicant tables seem to just be outliers in some local environments