### PR TITLE
IEN-800 - fix duplicate milestone in test env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ ifeq ($(ENV_NAME), test)
 DOMAIN=test.ien.freshworks.club
 NEXT_PUBLIC_AUTH_URL = https://common-logon-test.hlth.gov.bc.ca/auth
 BASTION_INSTANCE_ID = $(BASTION_INSTANCE_ID_TEST)
-DB_HOST = $(DB_HOST_PROD_TEST)
+DB_HOST = $(DB_HOST_TEST)
 endif
 
 define TFVARS_DATA

--- a/apps/api/src/migration/1676660208620-AddUniqueIndexForStatusJobDate.ts
+++ b/apps/api/src/migration/1676660208620-AddUniqueIndexForStatusJobDate.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUniqueIndexForStatusJobDate1676660208620 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // for some reason the test env did not create this unique index,
+    // writing a small migration just incase it happens in the future
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "unique_applicant_status_date_job"
+      ON "ien_applicant_status_audit" (applicant_id, status_id, start_date, job_id)
+      WHERE job_id IS NOT NULL
+    `);
+  }
+
+  public async down(): Promise<void> {
+    // no rollback
+  }
+}


### PR DESCRIPTION
The test environment did not have the unique index `unique_applicant_status_date_job`, can only assume there were already duplicates when it tried creating it?.  Local, dev and prod all have it and as far as I can tell no migration removing it.  Wrote a small migration just to prevent any further issues with it not being created

**Already removed the duplicate entries in Test