### PR TITLE
IEN 805 - fix cypress action failures

### DIFF
--- a/.github/workflows/pr-check-e2e.yml
+++ b/.github/workflows/pr-check-e2e.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: checkout
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - uses: actions/cache@v2
         name: Cache yarn
         with:

--- a/.github/workflows/pr-check-e2e.yml
+++ b/.github/workflows/pr-check-e2e.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: checkout
+      - uses: actions/setup-node@v2
+        name: Setup node
+        with:
+          node-version: 16
       - uses: actions/cache@v2
         name: Cache yarn
         with:

--- a/.github/workflows/pr-check-e2e.yml
+++ b/.github/workflows/pr-check-e2e.yml
@@ -15,10 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: checkout
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
       - uses: actions/cache@v2
         name: Cache yarn
         with:

--- a/.github/workflows/pr-check-pa11y.yml
+++ b/.github/workflows/pr-check-pa11y.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: checkout
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - uses: actions/cache@v2
         name: Cache yarn
         with:

--- a/.github/workflows/pr-check-pa11y.yml
+++ b/.github/workflows/pr-check-pa11y.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: checkout
+      - uses: actions/setup-node@v2
+        name: Setup node
+        with:
+          node-version: 16
       - uses: actions/cache@v2
         name: Cache yarn
         with:

--- a/.github/workflows/pr-check-pa11y.yml
+++ b/.github/workflows/pr-check-pa11y.yml
@@ -15,10 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: checkout
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
       - uses: actions/cache@v2
         name: Cache yarn
         with:

--- a/apps/web/cypress.json
+++ b/apps/web/cypress.json
@@ -1,6 +1,6 @@
 {
   "projectId": "zad925",
-  "baseUrl": "http://localhost:3000",
+  "baseUrl": "http://127.0.0.1:3000",
   "env": {
     "FAIL_FAST_STRATEGY": "run",
     "FAIL_FAST_ENABLED": true

--- a/apps/web/cypress.json
+++ b/apps/web/cypress.json
@@ -1,6 +1,6 @@
 {
   "projectId": "zad925",
-  "baseUrl": "http://127.0.0.1:3000",
+  "baseUrl": "http://localhost:3000",
   "env": {
     "FAIL_FAST_STRATEGY": "run",
     "FAIL_FAST_ENABLED": true

--- a/apps/web/src/components/applicant/ApplicantContext.tsx
+++ b/apps/web/src/components/applicant/ApplicantContext.tsx
@@ -6,10 +6,11 @@ import {
   useEffect,
   useState,
 } from 'react';
+import { useRouter } from 'next/router';
+
 import { ApplicantRO, ApplicantStatusAuditRO, ApplicantJobRO, isHired } from '@ien/common';
 import { getApplicant } from '@services';
 import { Spinner } from '../Spinner';
-import { useRouter } from 'next/router';
 import { useAuthContext } from '../AuthContexts';
 
 export const ApplicantContext = createContext<{

--- a/apps/web/src/components/applicant/ApplicantContext.tsx
+++ b/apps/web/src/components/applicant/ApplicantContext.tsx
@@ -6,13 +6,12 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { useRouter } from 'next/router';
-
 import { ApplicantRO, ApplicantStatusAuditRO, ApplicantJobRO, isHired } from '@ien/common';
 import { getApplicant } from '@services';
 import { Spinner } from '../Spinner';
+import { useRouter } from 'next/router';
 import { useAuthContext } from '../AuthContexts';
-// DO NOT MERGE
+
 export const ApplicantContext = createContext<{
   applicant: ApplicantRO;
   milestones: ApplicantStatusAuditRO[];

--- a/apps/web/src/components/applicant/ApplicantContext.tsx
+++ b/apps/web/src/components/applicant/ApplicantContext.tsx
@@ -6,12 +6,13 @@ import {
   useEffect,
   useState,
 } from 'react';
+import { useRouter } from 'next/router';
+
 import { ApplicantRO, ApplicantStatusAuditRO, ApplicantJobRO, isHired } from '@ien/common';
 import { getApplicant } from '@services';
 import { Spinner } from '../Spinner';
-import { useRouter } from 'next/router';
 import { useAuthContext } from '../AuthContexts';
-
+// DO NOT MERGE
 export const ApplicantContext = createContext<{
   applicant: ApplicantRO;
   milestones: ApplicantStatusAuditRO[];


### PR DESCRIPTION
Looks the `ubuntu-latest` default Node version changed recently to >17.x, even looks like its changing to 18.x soon ([here](https://github.com/actions/runner-images/issues/7002)).  The current Cypress version we use, 9.6.0 is only compatible with Node versions 12.x, 14.x and 16.x.  Could be a quick fix for now, unsure of any major changes trying to upgrade Cypress right now