### PR TITLE
IEN-812 fix sync user with ATS

### DIFF
--- a/apps/api/src/applicant/entity/ienusers.entity.ts
+++ b/apps/api/src/applicant/entity/ienusers.entity.ts
@@ -14,7 +14,6 @@ export class IENUsers {
   email?: string;
 
   // description: User's unique id from authentication system
-  @Index({ unique: true })
   @Column('varchar', { nullable: true })
   user_id?: string;
 

--- a/apps/api/src/applicant/external-api.service.ts
+++ b/apps/api/src/applicant/external-api.service.ts
@@ -106,10 +106,11 @@ export class ExternalAPIService {
           return {
             user_id: item.id.toLowerCase(),
             name: item.name,
-            email: item?.email,
+            email: item.email,
           };
         });
-        const result = await manager.upsert(IENUsers, listUsers, ['user_id']);
+        const result = await manager.upsert(IENUsers, listUsers, ['email']);
+
         this.logger.log(`${result.raw.length}/${listUsers.length} users updated`, 'ATS');
       }
     } catch (e) {
@@ -194,10 +195,6 @@ export class ExternalAPIService {
           `/applicants/ien?next=${per_page}&offset=${offset}&from=${from_date}&to=${to_date}`,
         ),
       );
-      this.logger.log(
-        `/applicants/ien?next=${per_page}&offset=${offset}&from=${from_date}&to=${to_date}`,
-        'ATS-SYNC',
-      );
       offset += per_page;
     }
     return pages;
@@ -232,7 +229,6 @@ export class ExternalAPIService {
       let temp: any[] = [];
       await Promise.all(pages).then(res => {
         res.forEach(r => {
-          this.logger.log(`${temp.length}, ${Array.isArray(r) ? r.length : 0}`, 'ATS-SYNC');
           temp = temp.concat(r);
         });
       });

--- a/apps/api/src/migration/1677871799880-DropUserIndexOnEmail.ts
+++ b/apps/api/src/migration/1677871799880-DropUserIndexOnEmail.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DropUserIndexOnEmail1677871799880 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('ien_users');
+    if (table) {
+      await queryRunner.dropIndex(table, 'IDX_6dce5313d82a7d8f5208cc005d');
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_6dce5313d82a7d8f5208cc005d" ON "ien_users" ("user_id") `,
+    );
+  }
+}


### PR DESCRIPTION
- remove the unique index on `user_id` <- it should be enforced by ATS
- use the unique index on `email` as a unique constraint to upsert users