### PR TITLE
IEN-810 Resolve GitHub actions warnings

### DIFF
--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'apps/api/**'
+      - 'apps/web/**'
       - 'packages/common/**'
 
 jobs:

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: checkout
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: ZAP Scan

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -15,7 +15,7 @@ jobs:
       name: dev
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         name: checkout
 
       - name: ZAP Scan

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -1,10 +1,10 @@
 name: ZAP Scan
 on:
-  pull_request:
-    paths:
-      - 'apps/api/**'
-      - 'apps/web/**'
-      - 'packages/common/**'
+  push:
+    branches:
+      - main
+    tags:
+      - security
 
 jobs:
   deploy:
@@ -17,9 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: checkout
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
+
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.4.0
         with:

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -1,10 +1,10 @@
 name: ZAP Scan
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - security
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 
 jobs:
   deploy:
@@ -15,8 +15,11 @@ jobs:
       name: dev
 
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
+      - name: checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.4.0

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -19,7 +19,7 @@ jobs:
         name: checkout
 
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.3.0
+        uses: zaproxy/action-full-scan@v0.4.0
         with:
           target: https://d309kopm8ags5f.cloudfront.net
           cmd_options: '-I'

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -1,10 +1,9 @@
 name: ZAP Scan
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - security
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'packages/common/**'
 
 jobs:
   deploy:

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -15,7 +15,7 @@ jobs:
       name: dev
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
 
       - name: ZAP Scan

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -15,9 +15,12 @@ jobs:
       name: dev
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
-
+ - uses: actions/setup-node@v3
+        name: Setup node
+        with:
+          node-version: 16
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.4.0
         with:

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -1,10 +1,10 @@
 name: ZAP Scan
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - security
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 
 jobs:
   deploy:
@@ -17,7 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: checkout
-
+        with:
+          node-version: 16
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.4.0
         with:

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -1,10 +1,10 @@
 name: ZAP Scan
 on:
-  pull_request:
-    paths:
-      - 'apps/api/**'
-      - 'apps/web/**'
-      - 'packages/common/**'
+  push:
+    branches:
+      - main
+    tags:
+      - security
 
 jobs:
   deploy:
@@ -17,10 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: checkout
- - uses: actions/setup-node@v3
-        name: Setup node
-        with:
-          node-version: 16
+
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.4.0
         with:

--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -1,10 +1,10 @@
 name: ZAP Scan
 on:
-  pull_request:
-    paths:
-      - 'apps/api/**'
-      - 'apps/web/**'
-      - 'packages/common/**'
+  push:
+    branches:
+      - main
+    tags:
+      - security
 
 jobs:
   deploy:
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
         with:
           node-version: 16
-
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.4.0
         with:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Infra
         run: make apply
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,8 +1,10 @@
 name: DEV - Deploy Apps
 on:
-  push:
-    tags:
-      - dev
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 env:
   TF_VERSION: 1.1.1
   ENV_NAME: dev

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,10 +1,8 @@
 name: DEV - Deploy Apps
 on:
-  pull_request:
-    paths:
-      - 'apps/api/**'
-      - 'apps/web/**'
-      - 'packages/common/**'
+  push:
+    tags:
+      - dev
 env:
   TF_VERSION: 1.1.1
   ENV_NAME: dev

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         name: checkout
 
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.TF_VERSION }}
           cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-skip-session-tagging: true
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,8 +1,10 @@
 name: DEV - Deploy Apps
 on:
-  push:
-    tags:
-      - dev
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 env:
   TF_VERSION: 1.1.1
   ENV_NAME: dev
@@ -17,9 +19,12 @@ jobs:
     environment:
       name: dev
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
-
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.TF_VERSION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -17,7 +17,7 @@ jobs:
     environment:
       name: dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
 
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,7 +17,7 @@ jobs:
     environment:
       name: prod
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
 
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,8 +1,10 @@
 name: PROD - Deploy Apps
 on:
-  push:
-    tags:
-      - prod
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 env:
   TF_VERSION: 1.1.1
   ENV_NAME: prod

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,10 +1,8 @@
 name: PROD - Deploy Apps
 on:
-  pull_request:
-    paths:
-      - 'apps/api/**'
-      - 'apps/web/**'
-      - 'packages/common/**'
+  push:
+    tags:
+      - prod
 env:
   TF_VERSION: 1.1.1
   ENV_NAME: prod

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         name: checkout
 
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.TF_VERSION }}
           cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-skip-session-tagging: true
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,7 +28,7 @@ jobs:
       # - name: Setup Infra
       #   run: make plan # Change to apply after verification
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,8 +1,10 @@
 name: PROD - Deploy Apps
 on:
-  push:
-    tags:
-      - prod
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 env:
   TF_VERSION: 1.1.1
   ENV_NAME: prod
@@ -17,9 +19,12 @@ jobs:
     environment:
       name: prod
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
-
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.TF_VERSION }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,8 +1,10 @@
 name: TEST - Deploy Apps
 on:
-  push:
-    tags:
-      - test
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 env:
   TF_VERSION: 1.1.1
   ENV_NAME: test
@@ -17,9 +19,12 @@ jobs:
     environment:
       name: test
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
-
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.TF_VERSION }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -17,7 +17,7 @@ jobs:
     environment:
       name: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
 
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Infra
         run: make apply
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,10 +1,8 @@
 name: TEST - Deploy Apps
 on:
-  pull_request:
-    paths:
-      - 'apps/api/**'
-      - 'apps/web/**'
-      - 'packages/common/**'
+  push:
+    tags:
+      - test
 env:
   TF_VERSION: 1.1.1
   ENV_NAME: test

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,8 +1,10 @@
 name: TEST - Deploy Apps
 on:
-  push:
-    tags:
-      - test
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 env:
   TF_VERSION: 1.1.1
   ENV_NAME: test

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         name: checkout
 
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.TF_VERSION }}
           cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-skip-session-tagging: true
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'apps/api/**'
+      - 'apps/web/**'
       - 'packages/common/**'
 
 jobs:

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'apps/api/**'
+      - 'apps/web/**'
       - 'packages/common/**'
 
 jobs:
@@ -10,8 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: actions/cache@v3
         name: Cache yarn
         with:

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     paths:
       - 'apps/api/**'
-      - 'apps/web/**'
       - 'packages/common/**'
 
 jobs:

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: checkout
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
       - uses: actions/cache@v2
         name: Cache yarn

--- a/.github/workflows/pr-check-common.yml
+++ b/.github/workflows/pr-check-common.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: checkout
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-common.yml
+++ b/.github/workflows/pr-check-common.yml
@@ -2,6 +2,8 @@ name: Common PR Checks
 on:
   pull_request:
     paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
       - 'packages/common/**'
 
 jobs:

--- a/.github/workflows/pr-check-common.yml
+++ b/.github/workflows/pr-check-common.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
       - uses: actions/cache@v2
         name: Cache yarn

--- a/.github/workflows/pr-check-common.yml
+++ b/.github/workflows/pr-check-common.yml
@@ -2,6 +2,8 @@ name: Common PR Checks
 on:
   pull_request:
     paths:
+      - 'apps/api/**'
+      - 'apps/web/**'
       - 'packages/common/**'
 
 jobs:
@@ -9,8 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: actions/cache@v3
         name: Cache yarn
         with:

--- a/.github/workflows/pr-check-common.yml
+++ b/.github/workflows/pr-check-common.yml
@@ -2,8 +2,6 @@ name: Common PR Checks
 on:
   pull_request:
     paths:
-      - 'apps/api/**'
-      - 'apps/web/**'
       - 'packages/common/**'
 
 jobs:

--- a/.github/workflows/pr-check-e2e.yml
+++ b/.github/workflows/pr-check-e2e.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: checkout
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         name: Setup node
         with:
           node-version: 16

--- a/.github/workflows/pr-check-e2e.yml
+++ b/.github/workflows/pr-check-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     environment:
       name: dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
       - uses: actions/setup-node@v2
         name: Setup node

--- a/.github/workflows/pr-check-e2e.yml
+++ b/.github/workflows/pr-check-e2e.yml
@@ -13,10 +13,10 @@ jobs:
     environment:
       name: dev
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
-      - uses: actions/setup-node@v3
-        name: Setup node
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - uses: actions/cache@v3

--- a/.github/workflows/pr-check-e2e.yml
+++ b/.github/workflows/pr-check-e2e.yml
@@ -19,7 +19,7 @@ jobs:
         name: Setup node
         with:
           node-version: 16
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-pa11y.yml
+++ b/.github/workflows/pr-check-pa11y.yml
@@ -13,7 +13,7 @@ jobs:
     environment:
       name: dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
       - uses: actions/setup-node@v2
         name: Setup node

--- a/.github/workflows/pr-check-pa11y.yml
+++ b/.github/workflows/pr-check-pa11y.yml
@@ -13,10 +13,10 @@ jobs:
     environment:
       name: dev
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
-      - uses: actions/setup-node@v3
-        name: Setup node
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - uses: actions/cache@v3

--- a/.github/workflows/pr-check-pa11y.yml
+++ b/.github/workflows/pr-check-pa11y.yml
@@ -19,7 +19,7 @@ jobs:
         name: Setup node
         with:
           node-version: 16
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-pa11y.yml
+++ b/.github/workflows/pr-check-pa11y.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: checkout
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         name: Setup node
         with:
           node-version: 16
@@ -50,7 +50,7 @@ jobs:
         run: make generate-accessibility-results
         if: ${{ failure() }}
 
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pr-check-tf.yml
+++ b/.github/workflows/pr-check-tf.yml
@@ -36,7 +36,7 @@ jobs:
       # https://github.com/hashicorp/setup-terraform#usage
 
       - name: Show Plan on PR
-        uses: actions/github-script@0.9.0
+        uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"

--- a/.github/workflows/pr-check-tf.yml
+++ b/.github/workflows/pr-check-tf.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       CLOUDFRONT_ID: '${{ secrets.CLOUDFRONT_ID }}'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
 
       - uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/pr-check-tf.yml
+++ b/.github/workflows/pr-check-tf.yml
@@ -2,9 +2,7 @@ name: Terraform PR Checks
 on:
   pull_request:
     paths:
-      - 'apps/api/**'
-      - 'apps/web/**'
-      - 'packages/common/**'
+      - 'terraform/**'
 env:
   TF_VERSION: 1.1.1
 

--- a/.github/workflows/pr-check-tf.yml
+++ b/.github/workflows/pr-check-tf.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Show Plan on PR
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
+        if: github.rest.event_name == 'pull_request'
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
         with:
@@ -53,7 +53,7 @@ jobs:
 
             </details>`;
               
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr-check-tf.yml
+++ b/.github/workflows/pr-check-tf.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         name: checkout
 
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.TF_VERSION }}
           cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}

--- a/.github/workflows/pr-check-tf.yml
+++ b/.github/workflows/pr-check-tf.yml
@@ -2,8 +2,9 @@ name: Terraform PR Checks
 on:
   pull_request:
     paths:
-      - 'terraform/**'
-
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 env:
   TF_VERSION: 1.1.1
 

--- a/.github/workflows/pr-check-tf.yml
+++ b/.github/workflows/pr-check-tf.yml
@@ -2,7 +2,9 @@ name: Terraform PR Checks
 on:
   pull_request:
     paths:
-      - 'terraform/**'
+      - 'apps/api/**'
+      - 'apps/web/**'
+      - 'packages/common/**'
 env:
   TF_VERSION: 1.1.1
 
@@ -14,8 +16,12 @@ jobs:
     env:
       CLOUDFRONT_ID: '${{ secrets.CLOUDFRONT_ID }}'
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - uses: hashicorp/setup-terraform@v2
         with:

--- a/.github/workflows/pr-check-web.yml
+++ b/.github/workflows/pr-check-web.yml
@@ -12,7 +12,7 @@ jobs:
     environment:
       name: dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
       - uses: actions/cache@v2
         name: Cache yarn

--- a/.github/workflows/pr-check-web.yml
+++ b/.github/workflows/pr-check-web.yml
@@ -2,7 +2,6 @@ name: Web PR Checks
 on:
   pull_request:
     paths:
-      - 'apps/api/**'
       - 'apps/web/**'
       - 'packages/common/**'
 

--- a/.github/workflows/pr-check-web.yml
+++ b/.github/workflows/pr-check-web.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: checkout
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-web.yml
+++ b/.github/workflows/pr-check-web.yml
@@ -2,6 +2,7 @@ name: Web PR Checks
 on:
   pull_request:
     paths:
+      - 'apps/api/**'
       - 'apps/web/**'
       - 'packages/common/**'
 
@@ -12,8 +13,12 @@ jobs:
     environment:
       name: dev
     steps:
-      - uses: actions/checkout@v3
-        name: checkout
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: actions/cache@v3
         name: Cache yarn
         with:

--- a/.github/workflows/pr-check-web.yml
+++ b/.github/workflows/pr-check-web.yml
@@ -2,6 +2,7 @@ name: Web PR Checks
 on:
   pull_request:
     paths:
+      - 'apps/api/**'
       - 'apps/web/**'
       - 'packages/common/**'
 

--- a/apps/api/test/04-report-4.e2e-spec.ts
+++ b/apps/api/test/04-report-4.e2e-spec.ts
@@ -81,6 +81,11 @@ describe('Report 4 - Number of IEN registrants in the licensing stage', () => {
     await app.close();
   });
 
+  it('Status 200 on report 4 response', async () => {
+    const { status } = await request(app.getHttpServer()).get(url);
+    expect(status).toBe(200);
+  });
+
   // update table report 4 endpoint reads from
   const updateCachedReport = async (data: ReportFourItem[]) => {
     reportFourObj.report_data = JSON.stringify(data);
@@ -130,26 +135,6 @@ describe('Report 4 - Number of IEN registrants in the licensing stage', () => {
     const { body: after } = await request(app.getHttpServer()).get(url);
 
     expect(after).toStrictEqual(expectedResult);
-  });
-
-  it('Applicants with "Withdrew from IEN program" status does not appear on report', async () => {
-    // The report output includes "Withdrew from IEN program" row,
-    // which should not increase with WITHDREW_FROM_PROGRAM milestone
-    const { body: before } = await request(app.getHttpServer()).get(url);
-
-    const updatedReport = await addMilestoneAndSplitProcess(reportService, {
-      applicantId: applicantIdsOldProcess[0],
-      status: STATUS.WITHDREW_FROM_PROGRAM,
-      period: periods[0],
-    });
-    await updateCachedReport(updatedReport);
-
-    const { body: after } = await request(app.getHttpServer()).get(url);
-
-    const beforeWithdrawnRow = getIndexOfStatus(before, STATUS.WITHDREW_FROM_PROGRAM);
-    const afterWithdrawnRow = getIndexOfStatus(after, STATUS.WITHDREW_FROM_PROGRAM);
-
-    expect(before[beforeWithdrawnRow]).toStrictEqual(after[afterWithdrawnRow]);
   });
 
   it('Applicant given BCCNM full license status should increase count on report', async () => {

--- a/apps/api/test/04-report-4.e2e-spec.ts
+++ b/apps/api/test/04-report-4.e2e-spec.ts
@@ -87,11 +87,6 @@ describe('Report 4 - Number of IEN registrants in the licensing stage', () => {
     await reportCacheRepository.upsert(reportFourObj, ['id']);
   };
 
-  it('Status 200 on report 4 response', async () => {
-    const { status } = await request(app.getHttpServer()).get(url);
-    expect(status).toBe(200);
-  });
-
   it('Add applicants and give each a different status/milestone (old process)', async () => {
     const { body: before } = await request(app.getHttpServer()).get(url);
 

--- a/apps/api/test/04-report-4.e2e-spec.ts
+++ b/apps/api/test/04-report-4.e2e-spec.ts
@@ -81,11 +81,6 @@ describe('Report 4 - Number of IEN registrants in the licensing stage', () => {
     await app.close();
   });
 
-  it('Status 200 on report 4 response', async () => {
-    const { status } = await request(app.getHttpServer()).get(url);
-    expect(status).toBe(200);
-  });
-
   // update table report 4 endpoint reads from
   const updateCachedReport = async (data: ReportFourItem[]) => {
     reportFourObj.report_data = JSON.stringify(data);

--- a/apps/api/test/04-report-4.e2e-spec.ts
+++ b/apps/api/test/04-report-4.e2e-spec.ts
@@ -87,6 +87,11 @@ describe('Report 4 - Number of IEN registrants in the licensing stage', () => {
     await reportCacheRepository.upsert(reportFourObj, ['id']);
   };
 
+  it('Status 200 on report 4 response', async () => {
+    const { status } = await request(app.getHttpServer()).get(url);
+    expect(status).toBe(200);
+  });
+
   it('Add applicants and give each a different status/milestone (old process)', async () => {
     const { body: before } = await request(app.getHttpServer()).get(url);
 

--- a/apps/api/test/04-report-4.e2e-spec.ts
+++ b/apps/api/test/04-report-4.e2e-spec.ts
@@ -81,6 +81,11 @@ describe('Report 4 - Number of IEN registrants in the licensing stage', () => {
     await app.close();
   });
 
+  it('Status 200 on report 4 response', async () => {
+    const { status } = await request(app.getHttpServer()).get(url);
+    expect(status).toBe(200);
+  });
+
   // update table report 4 endpoint reads from
   const updateCachedReport = async (data: ReportFourItem[]) => {
     reportFourObj.report_data = JSON.stringify(data);

--- a/apps/api/test/04-report-4.e2e-spec.ts
+++ b/apps/api/test/04-report-4.e2e-spec.ts
@@ -137,6 +137,26 @@ describe('Report 4 - Number of IEN registrants in the licensing stage', () => {
     expect(after).toStrictEqual(expectedResult);
   });
 
+  it('Applicants with "Withdrew from IEN program" status does not appear on report', async () => {
+    // The report output includes "Withdrew from IEN program" row,
+    // which should not increase with WITHDREW_FROM_PROGRAM milestone
+    const { body: before } = await request(app.getHttpServer()).get(url);
+
+    const updatedReport = await addMilestoneAndSplitProcess(reportService, {
+      applicantId: applicantIdsOldProcess[0],
+      status: STATUS.WITHDREW_FROM_PROGRAM,
+      period: periods[0],
+    });
+    await updateCachedReport(updatedReport);
+
+    const { body: after } = await request(app.getHttpServer()).get(url);
+
+    const beforeWithdrawnRow = getIndexOfStatus(before, STATUS.WITHDREW_FROM_PROGRAM);
+    const afterWithdrawnRow = getIndexOfStatus(after, STATUS.WITHDREW_FROM_PROGRAM);
+
+    expect(before[beforeWithdrawnRow]).toStrictEqual(after[afterWithdrawnRow]);
+  });
+
   it('Applicant given BCCNM full license status should increase count on report', async () => {
     const { body: before } = await request(app.getHttpServer()).get(url);
     const licenseBefore = reportFourNumberOfApplicants(


### PR DESCRIPTION
Was able to get the warning resolved for all but one in ZAP. Made the versions all the most recent for the ci-zap file. Found someone mentioning this issue in the GitHub repo for the action. They show that they updated to node 16 and suggest all action runs are displaying this and show where they updated.