### PR TITLE
IEN Hotfix - update ATS sync url format 

### DIFF
--- a/apps/api/src/applicant/external-api.service.ts
+++ b/apps/api/src/applicant/external-api.service.ts
@@ -192,7 +192,7 @@ export class ExternalAPIService {
     for (let i = 0; i < parallel_requests; i++) {
       pages.push(
         this.external_request.getApplicants(
-          `/applicants/ien?next=${per_page}&offset=${offset}&from=${from_date}&to=${to_date}`,
+          `/applicants?next=${per_page}&offset=${offset}&from=${from_date}&to=${to_date}`,
         ),
       );
       offset += per_page;

--- a/apps/api/src/common/external-request.ts
+++ b/apps/api/src/common/external-request.ts
@@ -26,26 +26,26 @@ export class ExternalRequest {
   }
 
   async getHa() {
-    return this.getData(`/health-authorities/ien`);
+    return this.getData(`/health-authorities`);
   }
 
   async getStaff() {
     const header = {
       ApiKey: process.env.HMBC_ATS_AUTH_KEY,
     };
-    return this.getData(`/applicants/staff/ien`, header);
+    return this.getData(`/staff`, header);
   }
 
   async getReason() {
-    return this.getData(`/withdrawal-reasons/ien`);
+    return this.getData(`/withdrawal-reasons`);
   }
 
   async getDepartment() {
-    return this.getData(`/specialty-departments/ien`);
+    return this.getData(`/specialty-departments`);
   }
 
   async getMilestone() {
-    return this.getData(`/milestones/ien`);
+    return this.getData(`/milestones`);
   }
 
   async getApplicants(url: string) {


### PR DESCRIPTION
The ATS sync has been broken for several days. The changed the format of their api, and issued new API keys. 
This PR updates the format of the affected routes. 