### PR TITLE
Updated migration to only conditionally create the foreign key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export $(shell sed 's/=.*//' ./.env)
 export PROJECT := ien
 
 # Runtime and application Environments specific variable
-export ENV_NAME ?= test
+export ENV_NAME ?= dev
 export POSTGRES_USERNAME ?= freshworks
 export CHES_CLIENT_ID ?= IEN_SERVICE_CLIENT
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export $(shell sed 's/=.*//' ./.env)
 export PROJECT := ien
 
 # Runtime and application Environments specific variable
-export ENV_NAME ?= dev
+export ENV_NAME ?= test
 export POSTGRES_USERNAME ?= freshworks
 export CHES_CLIENT_ID ?= IEN_SERVICE_CLIENT
 

--- a/apps/api/src/migration/1699550484811-RemoveDuplicateMilestone.ts
+++ b/apps/api/src/migration/1699550484811-RemoveDuplicateMilestone.ts
@@ -7,8 +7,40 @@ export class RemoveDuplicateMilestone1699550484811 implements MigrationInterface
     referencedTableName: 'ien_applicant_status',
   });
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // Get a list of all constraints on the ien_applicant_status table
+    const constraints: Array<{
+      column_name: string;
+      foreign_table_name: string;
+      foreign_column_name: string;
+    }> = await queryRunner.query(`
+        SELECT
+            tc.table_schema, 
+            tc.table_name, 
+            kcu.column_name, 
+            ccu.table_name AS foreign_table_name,
+            ccu.column_name AS foreign_column_name 
+        FROM information_schema.table_constraints AS tc 
+        JOIN information_schema.key_column_usage AS kcu
+            ON tc.constraint_name = kcu.constraint_name
+            AND tc.table_schema = kcu.table_schema
+        JOIN information_schema.constraint_column_usage AS ccu
+            ON ccu.constraint_name = tc.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+            AND tc.table_schema='public'
+            AND tc.table_name='ien_applicant_status_audit';
+    `);
+    // Check to see if the the foreign key already exists
+    if (
+      !constraints.find(
+        constraint =>
+          constraint.column_name === 'status_id' &&
+          constraint.foreign_table_name === 'ien_applicant_status' &&
+          constraint.foreign_column_name === 'id',
+      )
+    ) {
+      await queryRunner.createForeignKey('ien_applicant_status_audit', this.foreignKey);
+    }
     // Remove duplicate BCCNM Provisional Licence RPN and Signed Return of Service Agreement
-    await queryRunner.createForeignKey('ien_applicant_status_audit', this.foreignKey);
     await queryRunner.query(`
       UPDATE ien_applicant_status_audit 
       SET status_id = 'c29bb4d6-b3ad-4fd2-a7dc-2e7d53b35139' 


### PR DESCRIPTION
The Foreign key referenced in this migration already existed in test, causing the migration to fail and the application to stop functioning. 
Before creating the foreign key, I added a check to see if it already exists. 