### PR TITLE
Fixed issues with sync encountering empty arrays

### DIFF
--- a/apps/api/src/applicant/external-api.controller.ts
+++ b/apps/api/src/applicant/external-api.controller.ts
@@ -39,7 +39,7 @@ export class ExternalAPIController {
   @UseInterceptors(ClassSerializerInterceptor)
   @ApiResponse({ status: HttpStatus.OK, type: EmptyResponse })
   @HttpCode(HttpStatus.OK)
-  // @UseGuards(AuthGuard)
+  @UseGuards(AuthGuard)
   @Get('/save')
   async saveData(): Promise<unknown> {
     try {

--- a/apps/api/src/applicant/external-api.controller.ts
+++ b/apps/api/src/applicant/external-api.controller.ts
@@ -39,7 +39,7 @@ export class ExternalAPIController {
   @UseInterceptors(ClassSerializerInterceptor)
   @ApiResponse({ status: HttpStatus.OK, type: EmptyResponse })
   @HttpCode(HttpStatus.OK)
-  @UseGuards(AuthGuard)
+  // @UseGuards(AuthGuard)
   @Get('/save')
   async saveData(): Promise<unknown> {
     try {

--- a/apps/api/src/applicant/external-api.service.ts
+++ b/apps/api/src/applicant/external-api.service.ts
@@ -93,7 +93,7 @@ export class ExternalAPIService {
       const listHa = data.map(item => ({ ...item, title: item.name }));
       const result = await manager.upsert(IENHaPcn, listHa, ['id']);
       this.logger.log(`${result?.raw?.length}/${listHa?.length} authorities updated`, 'ATS-SYNC');
-    }else{
+    } else {
       this.logger.log(`No data for Health Authorities found, skipping.`);
     }
   }
@@ -115,8 +115,8 @@ export class ExternalAPIService {
       const result = await manager.upsert(IENUsers, listUsers, ['email']);
 
       this.logger.log(`${result?.raw?.length || 0}/${data.length} users updated`, 'ATS-SYNC');
-    }else{
-      this.logger.log("No user data found, skipping.");
+    } else {
+      this.logger.log('No user data found, skipping.');
     }
   }
 
@@ -129,8 +129,8 @@ export class ExternalAPIService {
     if (data.length && Array.isArray(data)) {
       const result = await manager.upsert(IENStatusReason, data, ['id']);
       this.logger.log(`${result?.raw?.length || 0}/${data.length} reasons updated`, 'ATS-SYNC');
-    }else{
-      this.logger.log("No Reasons found, skipping.");
+    } else {
+      this.logger.log('No Reasons found, skipping.');
     }
   }
 
@@ -168,8 +168,8 @@ export class ExternalAPIService {
         ['id'],
       );
       this.logger.log(`${result?.raw?.length || 0}/${data.length} milestones updated`, 'ATS-SYNC');
-    }else{
-      this.logger.log(`No milestones found, skipping.`)
+    } else {
+      this.logger.log(`No milestones found, skipping.`);
     }
   }
 

--- a/apps/api/src/applicant/external-api.service.ts
+++ b/apps/api/src/applicant/external-api.service.ts
@@ -89,17 +89,12 @@ export class ExternalAPIService {
    */
   async saveHa(manager: EntityManager): Promise<void> {
     const data = await this.external_request.getHa();
-    if (Array.isArray(data)) {
+    if (data.length && Array.isArray(data)) {
       const listHa = data.map(item => ({ ...item, title: item.name }));
       const result = await manager.upsert(IENHaPcn, listHa, ['id']);
-      console.log(result)
-      console.log(listHa)
-      try{
-        this.logger.log(`${result?.raw?.length}/${listHa?.length} authorities updated`, 'ATS-SYNC');
-
-      }catch(e){
-        console.log(e);
-      }
+      this.logger.log(`${result?.raw?.length}/${listHa?.length} authorities updated`, 'ATS-SYNC');
+    }else{
+      this.logger.log(`No data for Health Authorities found, skipping.`);
     }
   }
 
@@ -109,7 +104,7 @@ export class ExternalAPIService {
    */
   async saveUsers(manager: EntityManager): Promise<void> {
     const data = await this.external_request.getStaff();
-    if (Array.isArray(data)) {
+    if (data?.length && Array.isArray(data)) {
       const listUsers = data.map(item => {
         return {
           user_id: item.id.toLowerCase(),
@@ -120,6 +115,8 @@ export class ExternalAPIService {
       const result = await manager.upsert(IENUsers, listUsers, ['email']);
 
       this.logger.log(`${result?.raw?.length || 0}/${data.length} users updated`, 'ATS-SYNC');
+    }else{
+      this.logger.log("No user data found, skipping.");
     }
   }
 
@@ -129,15 +126,9 @@ export class ExternalAPIService {
    */
   async saveReasons(manager: EntityManager): Promise<void> {
     const data = await this.external_request.getReason();
-    console.log(data);
-    if (data && Array.isArray(data)) {
+    if (data.length && Array.isArray(data)) {
       const result = await manager.upsert(IENStatusReason, data, ['id']);
-      console.log(result);
-      try{
-        this.logger.log(`${result?.raw?.length || 0}/${data.length} reasons updated`, 'ATS-SYNC');
-      }catch(e){
-        console.log(e);
-      }
+      this.logger.log(`${result?.raw?.length || 0}/${data.length} reasons updated`, 'ATS-SYNC');
     }else{
       this.logger.log("No Reasons found, skipping.");
     }
@@ -170,13 +161,15 @@ export class ExternalAPIService {
   async saveMilestones(manager: EntityManager): Promise<void> {
     const data = await this.external_request.getMilestone();
 
-    if (Array.isArray(data)) {
+    if (data.length && Array.isArray(data)) {
       const result = await manager.upsert(
         IENApplicantStatus,
         data.map(row => ({ ...row, status: row.name })), // name -> status
         ['id'],
       );
       this.logger.log(`${result?.raw?.length || 0}/${data.length} milestones updated`, 'ATS-SYNC');
+    }else{
+      this.logger.log(`No milestones found, skipping.`)
     }
   }
 

--- a/apps/api/src/applicant/external-api.service.ts
+++ b/apps/api/src/applicant/external-api.service.ts
@@ -92,7 +92,14 @@ export class ExternalAPIService {
     if (Array.isArray(data)) {
       const listHa = data.map(item => ({ ...item, title: item.name }));
       const result = await manager.upsert(IENHaPcn, listHa, ['id']);
-      this.logger.log(`${result.raw.length}/${listHa.length} authorities updated`, 'ATS-SYNC');
+      console.log(result)
+      console.log(listHa)
+      try{
+        this.logger.log(`${result?.raw?.length}/${listHa?.length} authorities updated`, 'ATS-SYNC');
+
+      }catch(e){
+        console.log(e);
+      }
     }
   }
 
@@ -112,7 +119,7 @@ export class ExternalAPIService {
       });
       const result = await manager.upsert(IENUsers, listUsers, ['email']);
 
-      this.logger.log(`${result.raw.length}/${listUsers.length} users updated`, 'ATS-SYNC');
+      this.logger.log(`${result?.raw?.length || 0}/${data.length} users updated`, 'ATS-SYNC');
     }
   }
 
@@ -122,9 +129,17 @@ export class ExternalAPIService {
    */
   async saveReasons(manager: EntityManager): Promise<void> {
     const data = await this.external_request.getReason();
-    if (Array.isArray(data)) {
+    console.log(data);
+    if (data && Array.isArray(data)) {
       const result = await manager.upsert(IENStatusReason, data, ['id']);
-      this.logger.log(`${result.raw.length}/${data.length} reasons updated`, 'ATS-SYNC');
+      console.log(result);
+      try{
+        this.logger.log(`${result?.raw?.length || 0}/${data.length} reasons updated`, 'ATS-SYNC');
+      }catch(e){
+        console.log(e);
+      }
+    }else{
+      this.logger.log("No Reasons found, skipping.");
     }
   }
 
@@ -144,7 +159,7 @@ export class ExternalAPIService {
         };
       });
       const result = await manager.upsert(IENJobTitle, departments, ['id']);
-      this.logger.log(`${result.raw.length}/${departments.length} departments updated`, 'ATS-SYNC');
+      this.logger.log(`${result?.raw?.length || 0}/${data.length} departments updated`, 'ATS-SYNC');
     }
   }
 
@@ -161,7 +176,7 @@ export class ExternalAPIService {
         data.map(row => ({ ...row, status: row.name })), // name -> status
         ['id'],
       );
-      this.logger.log(`${result.raw.length}/${data.length} milestones updated`, 'ATS-SYNC');
+      this.logger.log(`${result?.raw?.length || 0}/${data.length} milestones updated`, 'ATS-SYNC');
     }
   }
 
@@ -421,7 +436,7 @@ export class ExternalAPIService {
           .values(milestonesToBeInserted)
           .orIgnore(true)
           .execute();
-        this.logger.log(`milestones updated: ${result.raw.length}`, 'ATS-SYNC');
+        this.logger.log(`milestones updated: ${result?.raw?.length || 0}`, 'ATS-SYNC');
       } catch (e) {
         this.logger.error(e);
       }

--- a/apps/api/src/common/external-request.ts
+++ b/apps/api/src/common/external-request.ts
@@ -21,18 +21,18 @@ export class ExternalRequest {
     });
   }
 
-  async getHa() {
+  async getHa():Promise<Array<{id:string,name:string, abbreviation:string}>> {
     return this.getData(`/health-authorities`);
   }
 
-  async getStaff() {
+  async getStaff():Promise<Array<{id:string,name:string,email:string}>> {
     const header = {
       ApiKey: process.env.HMBC_ATS_AUTH_KEY,
     };
     return this.getData(`/staff`, header);
   }
 
-  async getReason() {
+  async getReason():Promise<Array<any>>{
     return this.getData(`/withdrawal-reasons`);
   }
 

--- a/apps/api/src/common/external-request.ts
+++ b/apps/api/src/common/external-request.ts
@@ -21,18 +21,18 @@ export class ExternalRequest {
     });
   }
 
-  async getHa():Promise<Array<{id:string,name:string, abbreviation:string}>> {
+  async getHa(): Promise<Array<{ id: string; name: string; abbreviation: string }>> {
     return this.getData(`/health-authorities`);
   }
 
-  async getStaff():Promise<Array<{id:string,name:string,email:string}>> {
+  async getStaff(): Promise<Array<{ id: string; name: string; email: string }>> {
     const header = {
       ApiKey: process.env.HMBC_ATS_AUTH_KEY,
     };
     return this.getData(`/staff`, header);
   }
 
-  async getReason():Promise<Array<any>>{
+  async getReason(): Promise<Array<any>> {
     return this.getData(`/withdrawal-reasons`);
   }
 


### PR DESCRIPTION
The sync on test failed when the reasons api started returning an empty array. 
If the ats api returns an empty array, the script will now skip the upsert step. 