### PR TITLE
Added HA specific extracts for both milestone and applicant extracts

### DIFF
--- a/apps/api/src/report/report.service.ts
+++ b/apps/api/src/report/report.service.ts
@@ -786,7 +786,7 @@ export class ReportService {
     if (ha_pcn_id) {
       // Get the id for the referral milestone related to the HA PCN
       const HA_Milestone: [{ id: string }] = await entityManager.query(
-        this.getRefferalMilestone(ha_pcn_id),
+        this.getReferralMilestone(ha_pcn_id),
       );
       if (!HA_Milestone) {
         return [];

--- a/apps/api/src/report/report.util.service.ts
+++ b/apps/api/src/report/report.util.service.ts
@@ -745,7 +745,7 @@ export class ReportUtilService {
     });
 
     let userIDString = '';
-    if (userIds) {
+    if (userIds?.length) {
       userIDString = 'AND a.id IN (' + userIds.map(({ id }) => "'" + id + "'").join(',') + ')';
     }
 
@@ -786,7 +786,7 @@ export class ReportUtilService {
 
   extractApplicantMilestoneQuery(from: string, to: string, userIds: { id: string }[] | null) {
     let userIDString = '';
-    if (userIds) {
+    if (userIds?.length) {
       userIDString =
         'AND applicant.id IN (' + userIds.map(({ id }) => "'" + id + "'").join(',') + ')';
     }

--- a/apps/api/src/report/report.util.service.ts
+++ b/apps/api/src/report/report.util.service.ts
@@ -731,13 +731,24 @@ export class ReportUtilService {
     return this.getMilestoneIds(statuses, index >= 0 ? milestones.slice(index + 1) : []);
   }
 
-  extractApplicantsDataQuery(from: string, to: string, milestones: IENApplicantStatus[]) {
+  extractApplicantsDataQuery(
+    from: string,
+    to: string,
+    milestones: IENApplicantStatus[],
+    userIds?: { id: string }[],
+  ) {
     const milestone_ids: string[] = [];
     const milestoneList: string[] = [];
     milestones.forEach((item: { id: string; status: string }) => {
       milestone_ids.push(`"${item.id}" date`); // It will help to create dynamic column from json object
       milestoneList.push(`to_char(x."${item.id}", 'YYYY-MM-DD') as "${item.status}"`); // Display status name instead of id
     });
+
+    let userIDString = '';
+    if (userIds) {
+      userIDString = 'AND a.id IN (' + userIds.map(({ id }) => "'" + id + "'").join(',') + ')';
+    }
+
     const applicantColumns: string[] = [
       'a.id AS "Applicant ID"',
       'a.registration_date AS "Registration Date"',
@@ -768,11 +779,17 @@ export class ReportUtilService {
       ) as x("applicant_id" uuid, ${milestone_ids.join(',')}) ON x.applicant_id=a.id
     LEFT JOIN public.pathway p on a.pathway_id = p.id
     WHERE a.registration_date::date >= '${from}' AND a.registration_date::date <= '${to}'
+    ${userIDString}
     ORDER BY a.registration_date DESC
     `;
   }
 
-  extractApplicantMilestoneQuery(from: string, to: string, ha_pcn_id?: string | null) {
+  extractApplicantMilestoneQuery(from: string, to: string, userIds: { id: string }[] | null) {
+    let userIDString = '';
+    if (userIds) {
+      userIDString =
+        'AND applicant.id IN (' + userIds.map(({ id }) => "'" + id + "'").join(',') + ')';
+    }
     return `
     select milestone.applicant_id "Applicant ID", 
       applicant.registration_date "Registration Date", 
@@ -810,7 +827,6 @@ export class ReportUtilService {
     WHERE milestone.start_date::date >= '${from}' 
       AND milestone.start_date::date <= '${to}'
       AND ien_applicant_status.version = '2'
-      ${ha_pcn_id ? `AND ien_ha_pcn.id = '${ha_pcn_id}'` : ''}
       ORDER BY milestone.applicant_id
     `;
   }

--- a/apps/api/src/report/report.util.service.ts
+++ b/apps/api/src/report/report.util.service.ts
@@ -827,6 +827,7 @@ export class ReportUtilService {
     WHERE milestone.start_date::date >= '${from}' 
       AND milestone.start_date::date <= '${to}'
       AND ien_applicant_status.version = '2'
+      ${userIDString}
       ORDER BY milestone.applicant_id
     `;
   }

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -23,7 +23,7 @@ function App({ Component, pageProps }: AppProps) {
 
   useEffect(() => {
     setOidcConfig({
-      authority: `https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications`,
+      authority: `${process.env.NEXT_PUBLIC_AUTH_URL}/realms/${process.env.NEXT_PUBLIC_AUTH_REALM}`,
       client_id: process.env.NEXT_PUBLIC_AUTH_CLIENTID ?? 'IEN',
       redirect_uri: window.origin,
       onSigninCallback: (user: User | void) => {

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -23,7 +23,7 @@ function App({ Component, pageProps }: AppProps) {
 
   useEffect(() => {
     setOidcConfig({
-      authority: `${process.env.NEXT_PUBLIC_AUTH_URL}/realms/${process.env.NEXT_PUBLIC_AUTH_REALM}`,
+      authority: `https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications`,
       client_id: process.env.NEXT_PUBLIC_AUTH_CLIENTID ?? 'IEN',
       redirect_uri: window.origin,
       onSigninCallback: (user: User | void) => {


### PR DESCRIPTION
Updated data extracts. For HA users, only users who have a "referred to " milestone will have their milestones extracted. 

I added two steps to the process. The first takes the users HA PCN and finds the id of the "Applicant Referred to " milestone for that HA. The second selects a list of ids of users who have that milestone. 

The remainder is the main query, just with a check to ensure that only milestones from those users are selected. 