### PR TITLE
IEN-897 | Disable the period report cron job

### DIFF
--- a/terraform/report_lambda_function.tf
+++ b/terraform/report_lambda_function.tf
@@ -47,8 +47,8 @@ resource "aws_lambda_function" "CacheReports" {
 resource "aws_cloudwatch_event_rule" "cache_reports" {
   name                = local.cache_reports_lambda_name
   description         = "9:00AM UTC - 1:00AM PST Every day"
-  ## comment out the following line to disable the cron job
-  # schedule_expression = "cron(0 9 * * ? *)"
+  ## Invalid cron expression to disable the cron job
+  schedule_expression = "cron(0 0 0 0 0 0)" 
 }
 
 resource "aws_cloudwatch_event_target" "cache_reports" {

--- a/terraform/report_lambda_function.tf
+++ b/terraform/report_lambda_function.tf
@@ -45,10 +45,11 @@ resource "aws_lambda_function" "CacheReports" {
 }
 
 resource "aws_cloudwatch_event_rule" "cache_reports" {
+  ## Set count=0 to disable the cron job
+  count               = 0
   name                = local.cache_reports_lambda_name
-  description         = "9:00AM UTC - 1:00AM PST Every day"
-  ## Invalid cron expression to disable the cron job
-  schedule_expression = "cron(0 0 0 0 0 0)" 
+  description         = "9:00AM UTC - 1:00AM PST Every day"  
+  schedule_expression = "cron(0 9 * * ? *)" 
 }
 
 resource "aws_cloudwatch_event_target" "cache_reports" {

--- a/terraform/report_lambda_function.tf
+++ b/terraform/report_lambda_function.tf
@@ -55,7 +55,7 @@ resource "aws_cloudwatch_event_rule" "cache_reports" {
 resource "aws_cloudwatch_event_target" "cache_reports" {
   ## Set count=0 to disable the cron job
   count = 0
-  rule  = aws_cloudwatch_event_rule.cache_reports.name
+  rule  = aws_cloudwatch_event_rule.cache_reports[count.index].name
   arn   = aws_lambda_function.CacheReports.arn
   input = "{\"path\": \"cache-reports\"}"
 }
@@ -67,5 +67,5 @@ resource "aws_lambda_permission" "cache_reports" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.CacheReports.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.cache_reports.arn
+  source_arn    = aws_cloudwatch_event_rule.cache_reports[count.index].arn
 }

--- a/terraform/report_lambda_function.tf
+++ b/terraform/report_lambda_function.tf
@@ -53,12 +53,16 @@ resource "aws_cloudwatch_event_rule" "cache_reports" {
 }
 
 resource "aws_cloudwatch_event_target" "cache_reports" {
+  ## Set count=0 to disable the cron job
+  count = 0
   rule  = aws_cloudwatch_event_rule.cache_reports.name
   arn   = aws_lambda_function.CacheReports.arn
   input = "{\"path\": \"cache-reports\"}"
 }
 
 resource "aws_lambda_permission" "cache_reports" {
+  ## Set count=0 to disable the cron job
+  count         = 0
   statement_id  = "AllowExecutionFromCloudWatch_Morning"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.CacheReports.function_name


### PR DESCRIPTION
- It turns out comment out the `schedule_expression` failed deployment.
- So we add `count = 0` instead to disable it. And by using `count`, we have to add `[count.index]`.

I have verified by deploying this PR to DEV and see from the AWS console.

### AWS DEV (After deployed this PR)

![CleanShot 2024-08-22 at 10 38 42](https://github.com/user-attachments/assets/729ccb7f-4592-4582-8b41-c146dd9dfa07)

### AWS TEST (Before this PR)

![CleanShot 2024-08-22 at 10 40 25](https://github.com/user-attachments/assets/1383d4a6-e5d2-4eba-9870-6856b43fbb4d)
