### PR TITLE
IEN-923 | Enable HA Report Permission

### DIFF
--- a/apps/api/src/migration/1727200471805-AddBackReportRoleToHA.ts
+++ b/apps/api/src/migration/1727200471805-AddBackReportRoleToHA.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddBackReportRoleToHA1727200471805 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        INSERT INTO employee_roles_role (employee_id, role_id)
+        SELECT e.id, r.id
+        FROM employee e
+        JOIN ien_ha_pcn ha ON ha.title = e.organization
+        JOIN role r ON r.slug = 'reporting'
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM employee_roles_role err
+            WHERE err.employee_id = e.id
+            AND err.role_id = r.id
+        );
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        DELETE FROM employee_roles_role err
+        USING employee e, role r, ien_ha_pcn ha
+        WHERE
+            e.id = err.employee_id AND
+            ha.title = e.organization AND
+            r.id = err.role_id AND
+            r.slug = 'reporting';
+    `);
+  }
+}

--- a/apps/web/src/components/user/UserRoles.tsx
+++ b/apps/web/src/components/user/UserRoles.tsx
@@ -53,10 +53,7 @@ export const UserRoles = ({ user, updateUser }: UserRolesProps) => {
     if (isAdmin(user)) {
       return availableRoles;
     }
-    return availableRoles.filter(
-      role =>
-        role.slug !== RoleSlug.BccnmNcas && (!user.ha_pcn_id || role.slug !== RoleSlug.Reporting),
-    );
+    return availableRoles.filter(role => role.slug !== RoleSlug.BccnmNcas);
   };
 
   const getRoleSelector = (role: Role) => {


### PR DESCRIPTION
## Target
- Add back the report permission to HA user.
- It's most of the revert of this past PR (https://github.com/bcgov/internationally-educated-nurses/pull/592/files)

## Query
- The query inserts all HA employees without "reporting" role.

## Screenshots

- Have tested locally
![CleanShot 2024-09-24 at 11 14 59](https://github.com/user-attachments/assets/a23f5fbc-f00e-4879-acf1-26fca87c8cce)


- The report already only download the associated organization

![CleanShot 2024-09-24 at 11 17 37](https://github.com/user-attachments/assets/7b98dac9-31ce-406b-90a1-97da0950f1ad)

(Login myself as Fraser Health Authority)
![CleanShot 2024-09-24 at 11 19 51](https://github.com/user-attachments/assets/c2ac470e-b174-4e33-a3f5-d6fadc4b3a8c)

