### PR TITLE
IEN-921 | add limit as required

### DIFF
--- a/apps/api/src/applicant/dto/ienuser-filter.dto.ts
+++ b/apps/api/src/applicant/dto/ienuser-filter.dto.ts
@@ -1,7 +1,7 @@
-import { IsNumberString, IsOptional, IsString, IsDateString } from 'class-validator';
+import { IsNumberString, IsOptional, IsString, IsDateString, IsNotEmpty } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
-export class IENUserFilterAPIDTO {
+export class IENUserBaseFilterAPIDTO {
   @ApiPropertyOptional({
     description: 'Start date for range',
     example: '2020-01-01',
@@ -26,16 +26,29 @@ export class IENUserFilterAPIDTO {
   organization?: string;
 
   @ApiPropertyOptional({
-    description: 'Limit the number of results',
-  })
-  @IsOptional()
-  @IsNumberString()
-  limit?: number;
-
-  @ApiPropertyOptional({
     description: 'Skip the number of results',
   })
   @IsOptional()
   @IsNumberString()
   skip?: number;
+}
+export class IENUserFilterAPIDTO extends IENUserBaseFilterAPIDTO {
+  @ApiPropertyOptional({
+    description: 'Limit the number of results',
+  })
+  @IsOptional()
+  @IsNumberString()
+  limit?: number;
+}
+
+/**
+ * As class-validator does not override the decorator @IsOptional when override the parent class, we need to create a separate class for the filter with limit
+ */
+export class IENUserLimitFilterAPIDTO extends IENUserBaseFilterAPIDTO {
+  @ApiPropertyOptional({
+    description: 'Limit the number of results',
+  })
+  @IsNotEmpty()
+  @IsNumberString()
+  limit!: number;
 }

--- a/apps/api/src/applicant/external-api.controller.ts
+++ b/apps/api/src/applicant/external-api.controller.ts
@@ -24,6 +24,7 @@ import { IENUserFilterAPIDTO, SyncApplicantsResultDTO } from './dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { JWTGuard } from 'src/auth/jwt.guard';
 import { ApplicantSyncRO } from './ro/sync.ro';
+import { IENUserLimitFilterAPIDTO } from './dto/ienuser-filter.dto';
 
 @Controller('external-api')
 @ApiTags('External API data process')
@@ -140,7 +141,7 @@ export class ExternalAPIController {
   @UseGuards(JWTGuard)
   @ApiBearerAuth()
   @Get('/applicants')
-  async getApplicants(@Query() filter: IENUserFilterAPIDTO): Promise<ApplicantSyncRO[]> {
+  async getApplicants(@Query() filter: IENUserLimitFilterAPIDTO): Promise<ApplicantSyncRO[]> {
     return await this.externalAPIService.getApplicants(filter);
   }
 }


### PR DESCRIPTION
- As discussed, the endpoint functions correctly. We’ve added limit as a required field to prevent failures caused by large data responses.
- Since class-validator does not support overriding decorators, we had to create a base class instead of directly inheriting it.
(https://github.com/typestack/class-validator/issues/156)