### PR TITLE
IEN-928 | Add Feature Flag to HA access Report

### DIFF
--- a/apps/api/src/common/feature-flag.service.ts
+++ b/apps/api/src/common/feature-flag.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as AWS from 'aws-sdk';
+
+@Injectable()
+export class FeatureFlagService {
+  private readonly logger = new Logger(FeatureFlagService.name);
+  private readonly ssm = new AWS.SSM();
+
+  private static readonly FEATURE_FLAG_PREFIX = `/ien/${process.env.TARGET_ENV}/feature-flags`;
+
+  // we can extend here for future feature flags
+  static readonly FeatureFlags = {
+    CAN_HA_ACCESS_REPORT: `${FeatureFlagService.FEATURE_FLAG_PREFIX}/can_ha_access_report`,
+  };
+
+  /**
+   * Retrieves the feature flag value from AWS SSM Parameter Store.
+   * @param {string} featureFlag - The feature flag name in SSM.
+   * @returns {Promise<boolean>} - Returns true if the feature flag is enabled, false otherwise.
+   */
+  async getFeatureFlag(featureFlag: string): Promise<boolean> {
+    // If in local environment, return true
+    if (process.env.NODE_ENV !== 'production') {
+      this.logger.log(`LOCAL: Feature flag ${featureFlag} is set to: true`);
+      return true;
+    }
+
+    try {
+      const params = {
+        Name: featureFlag, // Use the feature flag name directly
+        WithDecryption: false, // We don't need decryption for plain text values
+      };
+
+      // Fetch the parameter from SSM
+      const result = await this.ssm.getParameter(params).promise();
+
+      // Convert the string "true"/"false" to a boolean value
+      const flagValue = result.Parameter?.Value === 'true';
+      this.logger.log(`Feature flag ${featureFlag} is set to: ${flagValue}`);
+      return flagValue;
+    } catch (error: any) {
+      this.logger.error(`Error fetching feature flag from SSM: ${error?.message}`);
+      return false; // Default to false if there's an error
+    }
+  }
+}

--- a/apps/api/src/common/feature-flag.service.ts
+++ b/apps/api/src/common/feature-flag.service.ts
@@ -6,7 +6,7 @@ export class FeatureFlagService {
   private readonly logger = new Logger(FeatureFlagService.name);
   private readonly ssm = new AWS.SSM();
 
-  private static readonly FEATURE_FLAG_PREFIX = `/ien/${process.env.TARGET_ENV}/feature-flags`;
+  private static readonly FEATURE_FLAG_PREFIX = `/ien/${process.env.TARGET_ENV}/feature_flags`;
 
   // we can extend here for future feature flags
   static readonly FeatureFlags = {

--- a/apps/api/src/employee/employee.module.ts
+++ b/apps/api/src/employee/employee.module.ts
@@ -7,6 +7,7 @@ import { IENUsers } from 'src/applicant/entity/ienusers.entity';
 import { EmployeeService } from './employee.service';
 import { RoleEntity } from './entity/role.entity';
 import { AccessEntity } from './entity/acl.entity';
+import { FeatureFlagService } from 'src/common/feature-flag.service';
 
 @Module({
   controllers: [EmployeeController],
@@ -14,7 +15,7 @@ import { AccessEntity } from './entity/acl.entity';
     TypeOrmModule.forFeature([EmployeeEntity, IENUsers, RoleEntity, AccessEntity]),
     forwardRef(() => AuthModule),
   ],
-  providers: [EmployeeService, Logger],
+  providers: [EmployeeService, Logger, FeatureFlagService],
   exports: [EmployeeService],
 })
 export class EmployeeModule {}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -46,3 +46,8 @@ resource "aws_iam_role_policy_attachment" "lambda_ses" {
   role       = aws_iam_role.lambda.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSESFullAccess"
 }
+
+resource "aws_iam_role_policy_attachment" "lambda_ssm" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -46,4 +46,14 @@ data "aws_ssm_parameter" "mail_recipients" {
 #   name = "/${var.project_code}/${var.target_env}/ches/auth_url"
 # }
 
+resource "aws_ssm_parameter" "feature_flag_can_ha_access_report" {
+  name  = "/${var.project_code}/${var.target_env}/feature_flags/can_ha_access_report"
+  type  = "String"
+  value = "false"
 
+  lifecycle {
+    ignore_changes = [
+      value, # Ignore changes to the value of the parameter
+    ]
+  }
+}


### PR DESCRIPTION
After digging more, I decide to use `parameter store` with `dynamic fetch the parameter` in api so that in the future we don't encounter terraform state inconsistent and easier to add more other feature flags.

- Because it's hard to add feature flag to the migration(previous enable HA PR: https://github.com/bcgov/internationally-educated-nurses/pull/656), so we implement this in api level to filter user role if it's HA user and with reporting role.
- If in local env, ignore the parameter store and always return true
- Have deployed to DEV and verified.
  - Tested redeploy terraform not override the existing value
  - Tested the feature flag functionality by toggling the value in parameter store

## Screenshots

- lambda can read the parameter

![CleanShot 2024-10-10 at 13 22 48](https://github.com/user-attachments/assets/3b013255-1a69-4040-ac11-80c9fbb2ba76)

- parameter store

![CleanShot 2024-10-10 at 13 25 11](https://github.com/user-attachments/assets/bef8a1bd-a6c0-4829-a0b9-b43c77f0f743)
