### PR TITLE
IEN HOTFIX | terraform command not found on github action env

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           role-to-assume: ${{secrets.AWS_SA_ROLE_ARN}}
           aws-region: ca-central-1
+      
+      - name: setup terraform
+        uses: hashicorp/setup-terraform@v3
 
       - name: Terraform apply
         run: make apply

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -44,6 +44,9 @@ jobs:
           role-to-assume: ${{secrets.AWS_SA_ROLE_ARN}}
           aws-region: ca-central-1
 
+      - name: setup terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Terraform apply
         run: make apply
 

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           role-to-assume: ${{secrets.AWS_SA_ROLE_ARN}}
           aws-region: ca-central-1
+      
+      - name: setup terraform
+        uses: hashicorp/setup-terraform@v3
 
       - name: Setup Infra
         run: make apply

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Git clone the repository
         uses: actions/checkout@v4
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{secrets.AWS_SA_ROLE_ARN}}
           aws-region: ca-central-1

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Git clone the repository
         uses: actions/checkout@v4
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{secrets.AWS_SA_ROLE_ARN}}
           aws-region: ca-central-1

--- a/.github/workflows/pr-check-tf.yml
+++ b/.github/workflows/pr-check-tf.yml
@@ -47,6 +47,9 @@ jobs:
           role-to-assume: ${{secrets.AWS_SA_ROLE_ARN}}
           aws-region: ca-central-1
 
+      - name: setup terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Terraform Plan
         id: plan
         run: make plan

--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ plan: init
 
 apply: init 
 	# Creating all AWS infrastructure.
-	@terraform -chdir=$(TERRAFORM_DIR) apply -auto-approve -input=false
+	@TF_LOG=DEBUG terraform -chdir=$(TERRAFORM_DIR) apply -auto-approve -input=false
 
 destroy: init
 	@terraform -chdir=$(TERRAFORM_DIR) destroy

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ write-config-tf:
 
 init: write-config-tf
 	# Initializing the terraform environment
-	@terraform -chdir=$(TERRAFORM_DIR) init -input=false \
+	@TF_LOG=DEBUG terraform -chdir=$(TERRAFORM_DIR) init -input=false \
 		-reconfigure \
 		-backend-config=backend.hcl \
 		-upgrade

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ write-config-tf:
 
 init: write-config-tf
 	# Initializing the terraform environment
-	@TF_LOG=DEBUG terraform -chdir=$(TERRAFORM_DIR) init -input=false \
+	@terraform -chdir=$(TERRAFORM_DIR) init -input=false \
 		-reconfigure \
 		-backend-config=backend.hcl \
 		-upgrade

--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ plan: init
 
 apply: init 
 	# Creating all AWS infrastructure.
-	@TF_LOG=DEBUG terraform -chdir=$(TERRAFORM_DIR) apply -auto-approve -input=false
+	@terraform -chdir=$(TERRAFORM_DIR) apply -auto-approve -input=false
 
 destroy: init
 	@terraform -chdir=$(TERRAFORM_DIR) destroy


### PR DESCRIPTION
## Issues
- Added `@TF_LOG=DEBUG terraform...` to makefile and see the log on github action, found that it shows `terraform command not found`
- I can not find why `ubuntu-latest` removed `terraform` on github action.

![CleanShot 2024-10-15 at 13 08 19](https://github.com/user-attachments/assets/eeeecb77-36b6-49fa-bdda-04525da3fcbc)

## Solutions
- Add https://github.com/hashicorp/setup-terraform to github action.

![CleanShot 2024-10-15 at 13 09 26](https://github.com/user-attachments/assets/7e6956fb-1647-4d35-8fbe-cd38e8e38d87)

