### PR TITLE
IEN-930 | IEN-938 | Automatic page refresh is clearing BCCNM upload data | Add variable pagination to the BCCNM/Inspire data review page

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           role-to-assume: ${{secrets.AWS_SA_ROLE_ARN}}
           aws-region: ca-central-1
-      
+
       - name: setup terraform
         uses: hashicorp/setup-terraform@v3
 

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           role-to-assume: ${{secrets.AWS_SA_ROLE_ARN}}
           aws-region: ca-central-1
-      
+
       - name: setup terraform
         uses: hashicorp/setup-terraform@v3
 

--- a/apps/web/cypress/support/commands.ts
+++ b/apps/web/cypress/support/commands.ts
@@ -181,10 +181,10 @@ Cypress.Commands.add('pagination', () => {
   cy.get('tbody > tr').should('have.length', 10);
   cy.contains('1 - 10');
 
-  // change limit to 30
-  cy.get('#user-page-top-size').click().type(`30{enter}`);
-  cy.contains('Showing 30');
-  cy.get('tbody > tr').should('have.length', 30);
+  // change limit to 5
+  cy.get('#user-page-top-size').click().type(`5{enter}`);
+  cy.contains('Showing 5');
+  cy.get('tbody > tr').should('have.length', 5);
 
   // move to page 3
   cy.get('#user-page-top-index').click().type(`3{enter}`);

--- a/apps/web/cypress/support/commands.ts
+++ b/apps/web/cypress/support/commands.ts
@@ -181,10 +181,10 @@ Cypress.Commands.add('pagination', () => {
   cy.get('tbody > tr').should('have.length', 10);
   cy.contains('1 - 10');
 
-  // change limit to 5
-  cy.get('#user-page-top-size').click().type(`5{enter}`);
-  cy.contains('Showing 5');
-  cy.get('tbody > tr').should('have.length', 5);
+  // change limit to 30
+  cy.get('#user-page-top-size').click().type(`30{enter}`);
+  cy.contains('Showing 30');
+  cy.get('tbody > tr').should('have.length', 30);
 
   // move to page 3
   cy.get('#user-page-top-index').click().type(`3{enter}`);

--- a/apps/web/src/components/Pagination.tsx
+++ b/apps/web/src/components/Pagination.tsx
@@ -13,20 +13,22 @@ export interface PaginationProps {
   id: string;
   pageOptions: PageOptions;
   onChange: (options: PageOptions) => void;
+  pageSizes?: number[];
 }
 
-const PAGE_SIZES = [5, 10, 30, 50, 100];
+const PAGE_SIZES = [5, 10, 25, 50];
 
 export const Pagination = (props: PaginationProps) => {
   const {
     id,
     pageOptions: { pageSize, pageIndex, total },
     onChange,
+    pageSizes = PAGE_SIZES, // if not provided, use default page sizes
   } = props;
 
   const numOfPages = Math.ceil(total / pageSize);
 
-  const pageSizeOptions = PAGE_SIZES.map(size => ({ value: size }));
+  const pageSizeOptions = pageSizes.map(size => ({ value: size }));
   const pageListOptions = Array.from(Array(numOfPages).keys()).map(i => ({ value: i + 1 }));
 
   const startIndex = (pageIndex - 1) * pageSize + 1;

--- a/apps/web/src/components/Pagination.tsx
+++ b/apps/web/src/components/Pagination.tsx
@@ -15,7 +15,7 @@ export interface PaginationProps {
   onChange: (options: PageOptions) => void;
 }
 
-const PAGE_SIZES = [10, 30, 50, 100];
+const PAGE_SIZES = [5, 10, 30, 50, 100];
 
 export const Pagination = (props: PaginationProps) => {
   const {

--- a/apps/web/src/components/Pagination.tsx
+++ b/apps/web/src/components/Pagination.tsx
@@ -15,7 +15,7 @@ export interface PaginationProps {
   onChange: (options: PageOptions) => void;
 }
 
-const PAGE_SIZES = [5, 10, 25, 50];
+const PAGE_SIZES = [10, 30, 50, 100];
 
 export const Pagination = (props: PaginationProps) => {
   const {

--- a/apps/web/src/components/admin/BccnmNcasPreview.tsx
+++ b/apps/web/src/components/admin/BccnmNcasPreview.tsx
@@ -52,12 +52,14 @@ export const BccnmNcasPreview = ({ data }: { data: BccnmNcasValidation[] }) => {
         id='bccnm-ncas-page-top'
         pageOptions={{ pageIndex, pageSize, total: filteredData.length }}
         onChange={handlePageOptions}
+        pageSizes={[10, 30, 50, 100]}
       />
       <BccnmNcasUpdateTable data={pagedData} />
       <Pagination
         id='bccnm-ncas-page-bottom'
         pageOptions={{ pageIndex, pageSize, total: filteredData.length }}
         onChange={handlePageOptions}
+        pageSizes={[10, 30, 50, 100]}
       />
     </>
   );

--- a/apps/web/src/components/admin/BccnmNcasSection.tsx
+++ b/apps/web/src/components/admin/BccnmNcasSection.tsx
@@ -5,10 +5,14 @@ import { BccnmNcasDataUploader } from './BccnmNcasDataUploader';
 import { BccnmNcasPreview } from './BccnmNcasPreview';
 import { applyBccnmNcasUpdates } from '../../services/admin';
 import { toast } from 'react-toastify';
+import { useSessionStorage } from './hooks/useSessionStorage';
 
 export const BccnmNcasSection = () => {
   const [uploaderOpen, setUploaderOpen] = useState(false);
-  const [data, setData] = useState<BccnmNcasValidation[]>();
+  const [data, setData] = useSessionStorage<BccnmNcasValidation[] | undefined>(
+    'BCCNM_UPLOAD_DATE',
+    undefined,
+  );
   const [loading, setLoading] = useState(false);
 
   const applyChanges = async () => {

--- a/apps/web/src/components/admin/hooks/useSessionStorage.tsx
+++ b/apps/web/src/components/admin/hooks/useSessionStorage.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable no-console */
+import { useState, useEffect } from 'react';
+
+// Custom hook to handle session storage in a type-safe manner
+export function useSessionStorage<T>(
+  key: string,
+  initialValue: T,
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = sessionStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.error('Failed to retrieve from sessionStorage', error);
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(key, JSON.stringify(storedValue));
+    } catch (error) {
+      console.error('Failed to save to sessionStorage', error);
+    }
+  }, [key, storedValue]);
+
+  // Cleanup session storage on page left
+  useEffect(() => {
+    const handleCleanSessionStorage = () => {
+      sessionStorage.removeItem(key);
+    };
+
+    return () => {
+      handleCleanSessionStorage();
+    };
+  }, [key]);
+
+  return [storedValue, setStoredValue];
+}


### PR DESCRIPTION
## Changes

- add `sessionStorage` to avoid reload clean; 
- modify page size to `5, 10 , 30, 50, 100`; (we keep `5` because of e2e testing using 5)
![CleanShot 2024-10-16 at 14 38 01](https://github.com/user-attachments/assets/24856059-952b-48f9-a68c-b78bcb8cd4e8)

- fix the previous terraform PR formatting issue to avoid the WebPR github action failure (previous PR did not have web change, hence not trigger the WebPR github action)
![CleanShot 2024-10-16 at 14 11 08](https://github.com/user-attachments/assets/76a07821-e3bd-4798-8521-394ce038729e)

## Screenshots

Have deployed to TEST and verified.
- can also verify by manually refreshing the page by clicking the refresh button on the browser.

- page size did exist before but modified to ideal number
![CleanShot 2024-10-16 at 14 08 24](https://github.com/user-attachments/assets/d3be5490-e7c7-4010-8c53-3d37c2f739c4)

