### PR TITLE
IEN-937 | Add restriction to BCCNM spreadsheet file upload

### DIFF
--- a/apps/web/src/components/FileUploader.tsx
+++ b/apps/web/src/components/FileUploader.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React, { useState } from 'react';
 import { toast } from 'react-toastify';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/apps/web/src/components/FileUploader.tsx
+++ b/apps/web/src/components/FileUploader.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useState } from 'react';
 import { toast } from 'react-toastify';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -20,11 +21,9 @@ export const FileUploader = ({ extensions, handleClose, open, upload }: FileUplo
     setFile(null);
   }
   const handleOnDrop = (files: File[]) => {
-    const ext = files[0]?.name.split('.').pop();
-    if (ext && extensions.includes(ext)) {
-      setFile(files[0]);
-    } else {
-      toast.warning(`Select a file of type: ${extensions.join(', ')}`);
+    const file = handleFileWithRestrictions(files[0], extensions);
+    if (file) {
+      setFile(file);
     }
   };
 
@@ -78,3 +77,27 @@ export const FileUploader = ({ extensions, handleClose, open, upload }: FileUplo
     </Modal>
   );
 };
+
+function handleFileWithRestrictions(file: File, extensions: string[] = []) {
+  try {
+    // file non-empty
+    // file extensions
+    // Dropzone would make file empty if extension is not correct, so we don't need to check for extension here
+    if (!file) {
+      throw new Error(`Select a file of type: ${extensions.join(', ')}`);
+    }
+
+    // file size < 6MB
+    if (file.size > 6 * 1024 * 1024) {
+      throw new Error('File is too large! Please select a file smaller than 6MB');
+    }
+
+    return file;
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      toast.warning(err.message);
+    } else {
+      console.error(`An unknown error occurred: ${err}`);
+    }
+  }
+}

--- a/apps/web/src/components/FileUploader.tsx
+++ b/apps/web/src/components/FileUploader.tsx
@@ -97,7 +97,7 @@ function handleFileWithRestrictions(file: File, extensions: string[] = []) {
     if (err instanceof Error) {
       toast.warning(err.message);
     } else {
-      console.error(`An unknown error occurred: ${err}`);
+      toast.error(`An unknown error occurred: ${err}`);
     }
   }
 }


### PR DESCRIPTION
## Changes

- Add file size 6MB restriction
- Refactor the existing code: Don't need to check extension as `react-dropzone` returns empty file if the ext is not correct.


## Screenshots
Deployed to TEST and verified.
- When the ext is not correct
![CleanShot 2024-10-17 at 11 03 21](https://github.com/user-attachments/assets/75764666-5d4d-4bc9-a1e3-41890715e587)

- When file size > 6MB
![CleanShot 2024-10-17 at 11 04 49](https://github.com/user-attachments/assets/21c87b0d-f5df-4f56-bb66-3d17d8ce52ce)

