### PR TITLE
IEN-931 | BCCNM/NCAS spreadsheet columns not being read

### DIFF
--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -165,7 +165,7 @@ export class AdminService {
 
     // bccnm/ncas completions accept 'Yes', 'No', or a date
     try {
-      v.appliedToBccnm = getDateFromCellValue(update['Date BCCNM Application Complete']);
+      v.appliedToBccnm = getDateFromCellValue(update['BCCNM Application Complete']);
     } catch (e) {
       v.message = e.message;
     }

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -165,13 +165,13 @@ export class AdminService {
 
     // bccnm/ncas completions accept 'Yes', 'No', or a date
     try {
-      v.appliedToBccnm = getDateFromCellValue(update['BCCNM Application Complete']);
+      v.appliedToBccnm = getDateFromCellValue(update['Date BCCNM Application Complete']);
     } catch (e) {
       v.message = e.message;
     }
 
     try {
-      v.ncasComplete = getDateFromCellValue(update['NCAS Assessment Complete']);
+      v.ncasComplete = getDateFromCellValue(update['Date NCAS Assessment Complete']);
     } catch (e) {
       v.message = e.message;
     }

--- a/apps/api/src/common/util.ts
+++ b/apps/api/src/common/util.ts
@@ -56,7 +56,7 @@ export function isNewBCCNMProcess(registration_date: string | Date | undefined) 
   return dayjs(registration_date).isAfter(OLD_BCCNM_PROCESS_CUT_OFF_DATE);
 }
 
-export function getDateFromCellValue(value: number | string): string | undefined {
+export function getDateFromCellValue(value: number | string | undefined): string | undefined {
   if (!value) return;
 
   if (typeof value === 'number') {

--- a/apps/api/test/13-bccnm-ncas-update.e2e-spec.ts
+++ b/apps/api/test/13-bccnm-ncas-update.e2e-spec.ts
@@ -59,7 +59,7 @@ describe('BCCNM/NCAS Updates', () => {
               'Last Name': applicant.name.split(' ')[1],
               'First Name': applicant.name.split(' ')[0],
               Email: applicant.email_address,
-              'NCAS Assessment Complete': 'Yes',
+              'Date NCAS Assessment Complete': '2022-10-01',
               'BCCNM Application Complete': 'Yes',
               'Registration Designation': 'BCCNM Provisional Licence LPN',
               'ISO Code - Education': 'kr',
@@ -78,7 +78,7 @@ describe('BCCNM/NCAS Updates', () => {
     dataToCreate.slice(4).forEach(v => {
       v['Date ROS Contract Signed'] = '';
       v['BCCNM Application Complete'] = 'No';
-      v['NCAS Assessment Complete'] = '';
+      v['Date NCAS Assessment Complete'] = '';
       v['ISO Code - Education'] = '';
     });
 

--- a/apps/api/test/13-bccnm-ncas-update.e2e-spec.ts
+++ b/apps/api/test/13-bccnm-ncas-update.e2e-spec.ts
@@ -59,7 +59,7 @@ describe('BCCNM/NCAS Updates', () => {
               'Last Name': applicant.name.split(' ')[1],
               'First Name': applicant.name.split(' ')[0],
               Email: applicant.email_address,
-              'Date NCAS Assessment Complete': '2022-10-01',
+              'Date NCAS Assessment Complete': '2024-10-01',
               'BCCNM Application Complete': 'Yes',
               'Registration Designation': 'BCCNM Provisional Licence LPN',
               'ISO Code - Education': 'kr',

--- a/packages/common/src/ro/bccnm-ncas-update.ts
+++ b/packages/common/src/ro/bccnm-ncas-update.ts
@@ -3,7 +3,7 @@ export interface BccnmNcasUpdate {
   'Date ROS Contract Signed': string | number;
   'First Name'?: string;
   'Last Name'?: string;
-  'NCAS Assessment Complete': string;
+  'Date NCAS Assessment Complete': string;
   'BCCNM Application Complete': string;
   'Registration Designation'?: string;
   'ISO Code - Education': string;


### PR DESCRIPTION
## Changes
- The column name in the client spreadsheet are the following:
![CleanShot 2024-10-30 at 12 37 49](https://github.com/user-attachments/assets/439771f6-4e46-4705-84ed-8b0536fbdd57)

## Testing locally
![CleanShot 2024-10-30 at 12 51 14](https://github.com/user-attachments/assets/e36c27df-decd-408e-9bef-6988846c53e7)
with the following `Test.xlsx`
![CleanShot 2024-10-30 at 12 55 11](https://github.com/user-attachments/assets/5dcbc71a-f312-4140-a2d4-ceb3223a6bf0)


[Test.xlsx](https://github.com/user-attachments/files/17578251/Test.xlsx)

## Notes

1. I found that there are some condition will remove the BCCNM and NCAS
![CleanShot 2024-10-30 at 12 39 31](https://github.com/user-attachments/assets/650750f8-efec-4114-8c4f-4c9fe6b5df92)

I am wondering the reason you saw no data is because of this?

2. I saw the Eduction is working fine