### PR TITLE
IEN-919 | End of Journey - Remove HA ability to mark candidate as Withdrew form competition

### DIFF
--- a/apps/web/src/components/milestone-logs/recruitment/MilestoneForm.tsx
+++ b/apps/web/src/components/milestone-logs/recruitment/MilestoneForm.tsx
@@ -33,6 +33,8 @@ import {
 } from '@components';
 import addIcon from '@assets/img/add.svg';
 import { DatePickerField } from '../../form/DatePickerField';
+import { useIsHAUser } from 'src/components/AuthContexts';
+import { createFilter } from '@utils/applicant-utils';
 
 type ReasonOption = StyleOption & IENStatusReasonRO;
 
@@ -65,6 +67,7 @@ export const MilestoneForm = <T extends MilestoneFormValues>(props: MilestoneFor
 
   const milestones = useGetMilestoneOptions(category);
   const reasons = useGetWithdrawReasonOptions();
+  const { isHAUser } = useIsHAUser();
 
   const [outcomeGroup, setOutcomeGroup] = useState<OutcomeGroup | null>(null);
   const [outcomeOptions, setOutcomeOptions] = useState<MilestoneType[]>([]);
@@ -132,8 +135,13 @@ export const MilestoneForm = <T extends MilestoneFormValues>(props: MilestoneFor
         setOutcomeOptions([]);
         return;
       }
-      const options = milestones.filter(option =>
-        outcomeGroup.milestones.includes(option.status as STATUS),
+      const options = milestones.filter(
+        createFilter([
+          // original condition
+          option => outcomeGroup.milestones.includes(option.status as STATUS),
+          // Additional Requirement IEN-919: Hide 'Withdrew from Competition' option for HA users
+          option => !isHAUser || option.status !== STATUS.WITHDREW_FROM_COMPETITION,
+        ]),
       );
       setOutcomeOptions(options);
     },

--- a/apps/web/src/utils/applicant-utils.ts
+++ b/apps/web/src/utils/applicant-utils.ts
@@ -11,3 +11,8 @@ export const getApplicantEducations = (applicant: ApplicantRO): string | undefin
     })
     .join(', ');
 };
+
+type Condition<T> = (option: T) => boolean;
+export const createFilter = <T>(conditions: Condition<T>[]): ((option: T) => boolean) => {
+  return (option: T) => conditions.every(condition => condition(option));
+};


### PR DESCRIPTION
## Changes
- refactor filter condition; 
- and add new condition: Ha user does not have withdraw option


## Screenshots
- Admin able to see withdrew:
![CleanShot 2024-11-01 at 13 21 58@2x](https://github.com/user-attachments/assets/58a59bdb-91a9-4c5b-aae4-b7721fea1b0b)

- Ha user not able to see withdrew:
![CleanShot 2024-11-01 at 13 19 11@2x](https://github.com/user-attachments/assets/4abc108c-3a91-4320-9333-3525d66ed731)
