### PR TITLE
IEN-920 | End of Journey Report

### DIFF
--- a/apps/web/src/services/report.ts
+++ b/apps/web/src/services/report.ts
@@ -408,6 +408,7 @@ export const createApplicantDataExtractWorkbook = async (
       return null;
     }
 
+    const EndOfJourneyColumn = 'End of Journey';
     const columns = [
       'Applicant ID',
       'Registration Date',
@@ -417,6 +418,7 @@ export const createApplicantDataExtractWorkbook = async (
       'Nursing Education',
       'Country of Citizenship',
       'Pathway',
+      EndOfJourneyColumn,
       'Type',
       ...MILESTONES,
     ];


### PR DESCRIPTION
- add `End of Journey` column to `milestone` extract with the following logic
```ts
/**
 * The `endOfJourneyColumn` defines a CASE statement that evaluates the journey status of an applicant.
 * It checks the `ien_applicant_status_audit` and `ien_applicant_status` tables to determine whether the applicant
 * has reached either 'End of Journey - Journey Complete' or 'End of Journey - Journey Incomplete' status.
 *
 * Logic:
 * - If there exists a record with 'End of Journey - Journey Complete' for the same `applicant_id`, the column
 *   is set to 'End of Journey - Journey Complete'.
 * - If no 'Journey Complete' record is found but a 'Journey Incomplete' record exists, the column is set to
 *   'End of Journey - Journey Incomplete'.
 * - If neither status exists for the applicant, the column value is set to NULL.
 */
```

![CleanShot 2024-11-06 at 13 05 24@2x](https://github.com/user-attachments/assets/358df3a4-185f-4bb4-a445-46b82c725a5e)


- similarly,  add `End of Journey` column to `applicant` extract

![CleanShot 2024-11-06 at 13 04 04@2x](https://github.com/user-attachments/assets/86c6155d-ab6d-423d-a265-c5008b58910c)
