### PR TITLE
IEN-947 | update github action checkout and related to v4

### DIFF
--- a/.github/workflows/ci-zap.yml
+++ b/.github/workflows/ci-zap.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.10.0
+        uses: zaproxy/action-full-scan@v0.12.0
         with:
           target: https://d309kopm8ags5f.cloudfront.net
           cmd_options: '-I'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,13 +23,13 @@ jobs:
       name: dev
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,13 +23,13 @@ jobs:
       name: prod
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -23,13 +23,13 @@ jobs:
       name: test
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -11,12 +11,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-common.yml
+++ b/.github/workflows/pr-check-common.yml
@@ -10,12 +10,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-e2e.yml
+++ b/.github/workflows/pr-check-e2e.yml
@@ -15,12 +15,12 @@ jobs:
       name: dev
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-pa11y.yml
+++ b/.github/workflows/pr-check-pa11y.yml
@@ -14,12 +14,12 @@ jobs:
       name: dev
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-tf.yml
+++ b/.github/workflows/pr-check-tf.yml
@@ -26,13 +26,13 @@ jobs:
       name: dev
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache yarn
         with:
           path: ./.yarn/cache

--- a/.github/workflows/pr-check-web.yml
+++ b/.github/workflows/pr-check-web.yml
@@ -13,12 +13,12 @@ jobs:
       name: dev
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node v18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache yarn
         with:
           path: ./.yarn/cache


### PR DESCRIPTION

![CleanShot 2024-12-19 at 09 26 59@2x](https://github.com/user-attachments/assets/322cb7ae-2ca0-4fca-ad74-12c86f5f078a)

## Issue
GitHub is removing version 3 of [upload-artifact](https://github.com/actions/upload-artifact) and [download-artifact](https://github.com/actions/download-artifact) by Jan 30, 2025. Update workflows to use version 4.

- We updated the related packages to version 4 and adjusted zap-scan to accommodate the changes in version 4.

## Changes
- update checkout@v4
- update cache@v4
- update setup-node@v4
- update zap-scan@0.12.0