### PR TITLE
IEN-939 | rename ncas to inspire (from user perspective)  IEN-954 | Fix broken a11y workflow

### DIFF
--- a/apps/api/src/migration/1736304205932-UpdateApplicantStatusFromNCASToInspire.ts
+++ b/apps/api/src/migration/1736304205932-UpdateApplicantStatusFromNCASToInspire.ts
@@ -1,0 +1,34 @@
+import { NCAS_NEW_NAME } from '@ien/common';
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateApplicantStatusFromNCASToInspire1736304205932 implements MigrationInterface {
+  // Define constants for clarity
+  private readonly OLD_VALUE = 'NCAS';
+  private readonly NEW_VALUE = NCAS_NEW_NAME;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Update specific status values
+    await queryRunner.query(`
+            UPDATE ien_applicant_status
+            SET status = CASE
+                WHEN status = 'Referred to ${this.OLD_VALUE}' THEN 'Referred to ${this.NEW_VALUE}'
+                WHEN status = 'Applied to ${this.OLD_VALUE}' THEN 'Applied to ${this.NEW_VALUE}'
+                WHEN status = 'Completed ${this.OLD_VALUE}' THEN 'Completed ${this.NEW_VALUE}'
+                ELSE status
+            END
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Revert specific status values back to NCAS
+    await queryRunner.query(`
+            UPDATE ien_applicant_status
+            SET status = CASE
+                WHEN status = 'Referred to ${this.NEW_VALUE}' THEN 'Referred to ${this.OLD_VALUE}'
+                WHEN status = 'Applied to ${this.NEW_VALUE}' THEN 'Applied to ${this.OLD_VALUE}'
+                WHEN status = 'Completed ${this.NEW_VALUE}' THEN 'Completed ${this.OLD_VALUE}'
+                ELSE status
+            END
+        `);
+  }
+}

--- a/apps/web/src/components/admin/BccnmNcasSection.tsx
+++ b/apps/web/src/components/admin/BccnmNcasSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { BccnmNcasValidation, pluralize } from '@ien/common';
+import { BccnmNcasValidation, pluralize, NCAS_NEW_NAME } from '@ien/common';
 import { buttonBase, buttonColor, Spinner } from '@components';
 import { BccnmNcasDataUploader } from './BccnmNcasDataUploader';
 import { BccnmNcasPreview } from './BccnmNcasPreview';
@@ -50,7 +50,9 @@ export const BccnmNcasSection = () => {
     <>
       <div className='bg-white p-4 mt-4'>
         <div className='flex flex-row justify-between'>
-          <h2 className='font-bold text-lg text-bcBluePrimary my-4'>Upload BCCNM/NCAS Data</h2>
+          <h2 className='font-bold text-lg text-bcBluePrimary my-4'>
+            Upload BCCNM/{NCAS_NEW_NAME} Data
+          </h2>
           <span>
             {data && (
               <button

--- a/packages/accessibility/src/pa11y-ci.js
+++ b/packages/accessibility/src/pa11y-ci.js
@@ -6,6 +6,9 @@ const defaults = {
     width: 1300,
     height: 1200,
   },
+  chromeLaunchConfig: {
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  },
 };
 
 const log = {

--- a/packages/common/src/constants/index.ts
+++ b/packages/common/src/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './authorities';
 export * from './countries.constants';
 export * from './outcome';
+export * from './ncas.constants';

--- a/packages/common/src/constants/ncas.constants.ts
+++ b/packages/common/src/constants/ncas.constants.ts
@@ -1,0 +1,1 @@
+export const NCAS_NEW_NAME = 'Inspire';

--- a/packages/common/src/enum/milestone-status.ts
+++ b/packages/common/src/enum/milestone-status.ts
@@ -4,10 +4,10 @@ export enum STATUS {
   RECEIVED_NNAS_REPORT = 'Received NNAS Report',
   COMPLETED_LANGUAGE_REQUIREMENT = 'Completed English Language Requirement',
   APPLIED_TO_BCCNM = 'Applied to BCCNM',
-  APPLIED_TO_NCAS = 'Applied to NCAS',
+  APPLIED_TO_NCAS = 'Applied to Inspire', // Renamed from NCAS to Inspire
   COMPLETED_CBA = 'Completed Computer-Based Assessment (CBA)',
   COMPLETED_SLA = 'Completed Simulation Lab Assessment (SLA)',
-  COMPLETED_NCAS = 'Completed NCAS',
+  COMPLETED_NCAS = 'Completed Inspire', // Renamed from NCAS to Inspire
   REFERRED_TO_ADDITIONAL_EDUCTION = 'Referred to Additional Education',
   COMPLETED_ADDITIONAL_EDUCATION = 'Completed Additional Education',
   REFERRED_TO_REGISTRATION_EXAM = 'Referred to Registration Exam',


### PR DESCRIPTION
- update status name from ncas to inspire in milestone table
![CleanShot 2025-01-08 at 11 03 55@2x](https://github.com/user-attachments/assets/749dad49-2154-4cbc-b318-0b9a66f18db9)

- update ui on Admin page
![CleanShot 2025-01-08 at 11 04 25@2x](https://github.com/user-attachments/assets/e8c2211b-2cd4-4f8e-a9b8-f2445626b51e)

- Fix broken a11y workflow (copied same fix from EHPR)

## Note
- In an enum, we cannot use variables, so we must use plain string values. That’s why we didn’t use the variable `NCAS_NEW_NAME` from `@ien/common`.
