### PR TITLE
INE-951 | Delete Applicant (Scramble PII)

### DIFF
--- a/apps/api/src/applicant/applicant.module.ts
+++ b/apps/api/src/applicant/applicant.module.ts
@@ -29,6 +29,7 @@ import { IENApplicantRecruiter } from './entity/ienapplicant-employee.entity';
 import { IENApplicantActiveFlag } from './entity/ienapplicant-active-flag.entity';
 import { Pathway } from './entity/pathway.entity';
 import { EndOfJourneyService } from './endofjourney.service';
+import { ScrambleService } from 'src/common/scramble.service';
 
 @Module({
   imports: [
@@ -63,6 +64,7 @@ import { EndOfJourneyService } from './endofjourney.service';
     ExternalAPIService,
     ExternalRequest,
     EndOfJourneyService,
+    ScrambleService,
   ],
   exports: [
     IENApplicantService,

--- a/apps/api/src/applicant/applicant.module.ts
+++ b/apps/api/src/applicant/applicant.module.ts
@@ -30,6 +30,7 @@ import { IENApplicantActiveFlag } from './entity/ienapplicant-active-flag.entity
 import { Pathway } from './entity/pathway.entity';
 import { EndOfJourneyService } from './endofjourney.service';
 import { ScrambleService } from 'src/common/scramble.service';
+import { EmployeeEntity } from 'src/employee/entity/employee.entity';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { ScrambleService } from 'src/common/scramble.service';
       IENStatusReason,
       Pathway,
       SyncApplicantsAudit,
+      EmployeeEntity,
     ]),
     EventEmitterModule.forRoot({ wildcard: true }),
     AuthModule,

--- a/apps/api/src/applicant/entity/ienapplicant.entity.ts
+++ b/apps/api/src/applicant/entity/ienapplicant.entity.ts
@@ -21,7 +21,13 @@ import { IENApplicantStatusAudit } from './ienapplicant-status-audit.entity';
 import { IENApplicantStatus } from './ienapplicant-status.entity';
 import { IENApplicantJob } from './ienjob.entity';
 import { IENUsers } from './ienusers.entity';
-import { ApplicantRO, IENUserRO, NursingEducationDTO, END_OF_JOURNEY_FLAG } from '@ien/common';
+import {
+  ApplicantRO,
+  IENUserRO,
+  NursingEducationDTO,
+  END_OF_JOURNEY_FLAG,
+  EmployeeRO,
+} from '@ien/common';
 import { EmployeeEntity } from '../../employee/entity/employee.entity';
 import { IENApplicantActiveFlag } from './ienapplicant-active-flag.entity';
 import { Pathway } from './pathway.entity';
@@ -95,6 +101,10 @@ export class IENApplicant {
   @JoinColumn({ name: 'updated_by_id' })
   updated_by!: IENUsers;
 
+  @ManyToOne(() => EmployeeEntity, employee => employee.id)
+  @JoinColumn({ name: 'deleted_by_id' })
+  deleted_by?: EmployeeRO;
+
   @OneToMany(() => IENApplicantJob, job => job.applicant)
   jobs!: IENApplicantJob[];
 
@@ -136,6 +146,19 @@ export class IENApplicant {
   @UpdateDateColumn()
   updated_date!: Date;
 
+  @Column({ type: 'timestamp', nullable: true })
+  deleted_date?: Date | null;
+
+  /**
+   * Backup information for the applicant after deletion (scramble PII)
+   */
+  @Column({ type: 'json', nullable: true })
+  backup?: {
+    name: string;
+    email_address: string;
+    phone_number: string;
+  } | null;
+
   @AfterLoad()
   sortStatus() {
     if (this?.applicant_status_audit?.length) {
@@ -175,6 +198,8 @@ export class IENApplicant {
       updated_date: this.updated_date,
       pathway: this.pathway,
       end_of_journey: this.end_of_journey,
+      deleted_date: this.deleted_date,
+      deleted_by: this.deleted_by,
     };
   }
 }

--- a/apps/api/src/applicant/entity/ienapplicant.entity.ts
+++ b/apps/api/src/applicant/entity/ienapplicant.entity.ts
@@ -14,8 +14,6 @@ import {
   BeforeInsert,
   ManyToMany,
   JoinTable,
-  BeforeUpdate,
-  AfterUpdate,
 } from 'typeorm';
 
 import { IENApplicantAudit } from './ienapplicant-audit.entity';
@@ -165,34 +163,6 @@ export class IENApplicant {
   sortStatus() {
     if (this?.applicant_status_audit?.length) {
       this.applicant_status_audit = sortStatus(this.applicant_status_audit);
-    }
-  }
-
-  /**
-   * Check if the deleted_date is set before updating the entity, this is for syncronization with the ATS preventing updates to scrambled data
-   */
-  // Temporary properties to store original values
-  private originalName?: string;
-  private originalEmailAddress?: string;
-  private originalPhoneNumber?: string;
-  @BeforeUpdate()
-  storeOriginalDataOnUpdate() {
-    this.originalName = this.name;
-    this.originalEmailAddress = this.email_address;
-    this.originalPhoneNumber = this.phone_number;
-  }
-  @AfterUpdate()
-  checkDeletedDateBeforeUpdate() {
-    if (this.deleted_date) {
-      if (this.originalName) {
-        this.name = this.originalName; // Keep existing value
-      }
-      if (this.originalEmailAddress) {
-        this.email_address = this.originalEmailAddress; // Keep existing value
-      }
-      if (this.originalPhoneNumber) {
-        this.phone_number = this.originalPhoneNumber; // Keep existing value
-      }
     }
   }
 

--- a/apps/api/src/applicant/entity/ienapplicant.entity.ts
+++ b/apps/api/src/applicant/entity/ienapplicant.entity.ts
@@ -14,6 +14,7 @@ import {
   BeforeInsert,
   ManyToMany,
   JoinTable,
+  BeforeUpdate,
 } from 'typeorm';
 
 import { IENApplicantAudit } from './ienapplicant-audit.entity';
@@ -165,6 +166,19 @@ export class IENApplicant {
       this.applicant_status_audit = sortStatus(this.applicant_status_audit);
     }
   }
+
+  /**
+   * Check if the deleted_date is set before updating the entity, this is for syncronization with the ATS preventing updates to scrambled data
+   */
+  @BeforeUpdate()
+  checkDeletedDateBeforeUpdate() {
+    if (this.deleted_date) {
+      this.name = this.name; // Keep existing value
+      this.email_address = this.email_address; // Keep existing value
+      this.phone_number = this.phone_number; // Keep existing value
+    }
+  }
+
   toResponseObject(): ApplicantRO {
     return {
       id: this.id,

--- a/apps/api/src/applicant/entity/ienapplicant.entity.ts
+++ b/apps/api/src/applicant/entity/ienapplicant.entity.ts
@@ -15,6 +15,7 @@ import {
   ManyToMany,
   JoinTable,
   BeforeUpdate,
+  AfterUpdate,
 } from 'typeorm';
 
 import { IENApplicantAudit } from './ienapplicant-audit.entity';
@@ -170,12 +171,28 @@ export class IENApplicant {
   /**
    * Check if the deleted_date is set before updating the entity, this is for syncronization with the ATS preventing updates to scrambled data
    */
+  // Temporary properties to store original values
+  private originalName?: string;
+  private originalEmailAddress?: string;
+  private originalPhoneNumber?: string;
   @BeforeUpdate()
+  storeOriginalDataOnUpdate() {
+    this.originalName = this.name;
+    this.originalEmailAddress = this.email_address;
+    this.originalPhoneNumber = this.phone_number;
+  }
+  @AfterUpdate()
   checkDeletedDateBeforeUpdate() {
     if (this.deleted_date) {
-      this.name = this.name; // Keep existing value
-      this.email_address = this.email_address; // Keep existing value
-      this.phone_number = this.phone_number; // Keep existing value
+      if (this.originalName) {
+        this.name = this.originalName; // Keep existing value
+      }
+      if (this.originalEmailAddress) {
+        this.email_address = this.originalEmailAddress; // Keep existing value
+      }
+      if (this.originalPhoneNumber) {
+        this.phone_number = this.originalPhoneNumber; // Keep existing value
+      }
     }
   }
 

--- a/apps/api/src/applicant/entity/ienapplicant.subscriber.ts
+++ b/apps/api/src/applicant/entity/ienapplicant.subscriber.ts
@@ -1,0 +1,21 @@
+// ienapplicant.subscriber.ts
+import { EntitySubscriberInterface, EventSubscriber, UpdateEvent } from 'typeorm';
+import { IENApplicant } from './ienapplicant.entity';
+
+@EventSubscriber()
+export class IENApplicantSubscriber implements EntitySubscriberInterface<IENApplicant> {
+  listenTo() {
+    return IENApplicant;
+  }
+
+  beforeUpdate(event: UpdateEvent<IENApplicant>) {
+    const entity = event.entity;
+    const databaseEntity = event.databaseEntity;
+
+    if (entity && databaseEntity && entity.deleted_date) {
+      entity.name = databaseEntity.name;
+      entity.email_address = databaseEntity.email_address;
+      entity.phone_number = databaseEntity.phone_number;
+    }
+  }
+}

--- a/apps/api/src/applicant/entity/ienapplicant.subscriber.ts
+++ b/apps/api/src/applicant/entity/ienapplicant.subscriber.ts
@@ -14,13 +14,13 @@ export class IENApplicantSubscriber implements EntitySubscriberInterface<IENAppl
     const { entity, manager } = event;
 
     // If there's no entity or the entity has no ats1_id do nothing
-    if (!entity || !entity.ats1_id) return;
+    if (!entity?.ats1_id) return;
 
     // Retrieve the original entity from the database
     const databaseEntity = await manager.findOne(IENApplicant, { ats1_id: entity.ats1_id });
 
     // If the original entity is found and it's marked as deleted,, revert the changes for the specified fields
-    if (databaseEntity && databaseEntity.deleted_date) {
+    if (databaseEntity?.deleted_date) {
       entity.name = databaseEntity.name;
       entity.email_address = databaseEntity.email_address;
       entity.phone_number = databaseEntity.phone_number;

--- a/apps/api/src/applicant/ienapplicant.controller.ts
+++ b/apps/api/src/applicant/ienapplicant.controller.ts
@@ -403,4 +403,22 @@ export class IENApplicantController {
       );
     }
   }
+
+  @ApiOperation({
+    summary: 'Delete applicant (scramble PII and keep milestones)',
+  })
+  @UseInterceptors(ClassSerializerInterceptor)
+  @Delete('/:id')
+  @AllowAccess(Access.APPLICANT_WRITE)
+  async deleteApplicant(@Req() req: RequestObj, @Param('id') id: string): Promise<void> {
+    try {
+      this.logger.log(
+        `Delete applicant (${id}) requested by
+        userId (${req?.user.user_id})/ employeeId/loginId (${req?.user.id})`,
+      );
+      return this.ienapplicantService.deleteApplicant(id);
+    } catch (e) {
+      throw this._handleStatusException(e);
+    }
+  }
 }

--- a/apps/api/src/applicant/ienapplicant.controller.ts
+++ b/apps/api/src/applicant/ienapplicant.controller.ts
@@ -409,7 +409,7 @@ export class IENApplicantController {
   })
   @UseInterceptors(ClassSerializerInterceptor)
   @Delete('/:id')
-  @AllowAccess(Access.APPLICANT_WRITE)
+  @AllowAccess(Access.APPLICANT_WRITE, Access.ADMIN)
   async deleteApplicant(@Req() req: RequestObj, @Param('id') id: string): Promise<void> {
     try {
       this.logger.log(

--- a/apps/api/src/applicant/ienapplicant.controller.ts
+++ b/apps/api/src/applicant/ienapplicant.controller.ts
@@ -416,7 +416,7 @@ export class IENApplicantController {
         `Delete applicant (${id}) requested by
         userId (${req?.user.user_id})/ employeeId/loginId (${req?.user.id})`,
       );
-      return this.ienapplicantService.deleteApplicant(id);
+      return this.ienapplicantService.deleteApplicant(req?.user.id, id);
     } catch (e) {
       throw this._handleStatusException(e);
     }

--- a/apps/api/src/applicant/ienapplicant.service.ts
+++ b/apps/api/src/applicant/ienapplicant.service.ts
@@ -681,7 +681,6 @@ export class IENApplicantService {
 
     await getManager().transaction(async manager => {
       const deleted_by_data = await this.employeeRepository.findOne(user_id);
-      console.log('deleted_by_data::::', user_id, deleted_by_data);
       await manager.update<IENApplicant>(IENApplicant, id, {
         name: scrambledName,
         email_address: scrambledEmail,

--- a/apps/api/src/applicant/ienapplicant.service.ts
+++ b/apps/api/src/applicant/ienapplicant.service.ts
@@ -57,7 +57,7 @@ export class IENApplicantService {
     private eventEmitter: EventEmitter2,
     private readonly scrambleService: ScrambleService,
     @InjectRepository(EmployeeEntity)
-    private employeeRepository: Repository<EmployeeEntity>,
+    private readonly employeeRepository: Repository<EmployeeEntity>,
   ) {}
 
   /**

--- a/apps/api/src/common/scramble.service.ts
+++ b/apps/api/src/common/scramble.service.ts
@@ -14,7 +14,10 @@ export class ScrambleService {
     const characters = hash.split('');
     // Scramble the array using crypto for better randomness
     for (let i = characters.length - 1; i > 0; i--) {
-      const randomValue = randomBytes(1)[0];
+      let randomValue;
+      do {
+        randomValue = randomBytes(1)[0];
+      } while (randomValue >= 256 - (256 % (i + 1)));
       const j = randomValue % (i + 1);
       [characters[i], characters[j]] = [characters[j], characters[i]];
     }

--- a/apps/api/src/common/scramble.service.ts
+++ b/apps/api/src/common/scramble.service.ts
@@ -45,6 +45,12 @@ export class ScrambleService {
     if (!phone) {
       return '';
     }
-    return phone.replace(/\d/g, () => (randomBytes(1)[0] % 10).toString());
+    return phone.replace(/\d/g, () => {
+      let randomValue;
+      do {
+        randomValue = randomBytes(1)[0];
+      } while (randomValue >= 250);
+      return (randomValue % 10).toString();
+    });
   }
 }

--- a/apps/api/src/common/scramble.service.ts
+++ b/apps/api/src/common/scramble.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ScrambleService {
+  // Scramble a string by shuffling its characters
+  scrambleText(input: string | undefined): string {
+    if (!input) {
+      return '';
+    }
+    return input
+      .split('')
+      .sort(() => Math.random() - 0.5)
+      .join('');
+  }
+
+  // Scramble an email by shuffling the local part and domain
+  scrambleEmail(email: string | undefined): string {
+    if (!email) {
+      return '';
+    }
+    const [local, domain] = email.split('@');
+    if (local && domain) {
+      return `${this.scrambleText(local)}@${this.scrambleText(domain)}`;
+    }
+    return this.scrambleText(email); // In case email is malformed
+  }
+
+  // Scramble a phone number while keeping the format (e.g., keep dashes and parentheses)
+  scramblePhone(phone: string | undefined): string {
+    if (!phone) {
+      return '';
+    }
+    return phone.replace(/\d/g, () => Math.floor(Math.random() * 10).toString());
+  }
+}

--- a/apps/api/src/common/scramble.service.ts
+++ b/apps/api/src/common/scramble.service.ts
@@ -1,28 +1,40 @@
 import { Injectable } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
 
 @Injectable()
 export class ScrambleService {
-  // Scramble a string by shuffling its characters
+  // Scramble a string by hashing it and then shuffling the hash, returning only the first 10 characters
   scrambleText(input: string | undefined): string {
     if (!input) {
       return '';
     }
-    return input
-      .split('')
-      .sort(() => Math.random() - 0.5)
-      .join('');
+    // Create a SHA-256 hash of the input string
+    const hash = createHash('sha256').update(input).digest('hex');
+    // Convert the hash into an array of characters
+    const characters = hash.split('');
+    // Scramble the array using crypto for better randomness
+    for (let i = characters.length - 1; i > 0; i--) {
+      const randomValue = randomBytes(1)[0];
+      const j = randomValue % (i + 1);
+      [characters[i], characters[j]] = [characters[j], characters[i]];
+    }
+    // Join the scrambled characters back into a string and return only the first 10 characters
+    const scrambledHash = characters.join('').substring(0, 10);
+    return scrambledHash;
   }
 
-  // Scramble an email by shuffling the local part and domain
+  // Scramble an email by shuffling the local part and domain, returning only the first 10 characters
   scrambleEmail(email: string | undefined): string {
     if (!email) {
       return '';
     }
     const [local, domain] = email.split('@');
     if (local && domain) {
-      return `${this.scrambleText(local)}@${this.scrambleText(domain)}`;
+      const scrambledLocal = this.scrambleText(local).substring(0, 5);
+      const scrambledDomain = this.scrambleText(domain).substring(0, 5);
+      return `${scrambledLocal}@${scrambledDomain}`;
     }
-    return this.scrambleText(email); // In case email is malformed
+    return this.scrambleText(email).substring(0, 10); // In case email is malformed
   }
 
   // Scramble a phone number while keeping the format (e.g., keep dashes and parentheses)
@@ -30,6 +42,6 @@ export class ScrambleService {
     if (!phone) {
       return '';
     }
-    return phone.replace(/\d/g, () => Math.floor(Math.random() * 10).toString());
+    return phone.replace(/\d/g, () => (randomBytes(1)[0] % 10).toString());
   }
 }

--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -24,6 +24,7 @@ import { ReportCacheEntity } from 'src/report/entity/report-cache.entity';
 import { IENApplicantRecruiter } from '../applicant/entity/ienapplicant-employee.entity';
 import { IENApplicantActiveFlag } from 'src/applicant/entity/ienapplicant-active-flag.entity';
 import { Pathway } from '../applicant/entity/pathway.entity';
+import { IENApplicantSubscriber } from 'src/applicant/entity/ienapplicant.subscriber';
 
 const getEnvironmentSpecificConfig = (env?: string): Partial<PostgresConnectionOptions> => {
   switch (env) {
@@ -90,6 +91,7 @@ const appOrmConfig: PostgresConnectionOptions = {
   ...environmentSpecificConfig,
   synchronize: false,
   migrationsRun: true,
+  subscribers: [IENApplicantSubscriber],
 };
 
 @Module({

--- a/apps/api/src/migration/1737077728589-AddDeleteInfoAndBackupToIenApplicants.ts
+++ b/apps/api/src/migration/1737077728589-AddDeleteInfoAndBackupToIenApplicants.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddDeleteInfoAndBackupToIenApplicants1737077728589 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('ien_applicants', [
+      new TableColumn({
+        name: 'deleted_by_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'deleted_date',
+        type: 'timestamp',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'backup',
+        type: 'jsonb',
+        isNullable: true,
+        default: null,
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumns('ien_applicants', ['deleted_by_id', 'deleted_date', 'backup']);
+  }
+}

--- a/apps/web/src/components/Button.tsx
+++ b/apps/web/src/components/Button.tsx
@@ -17,6 +17,7 @@ export const buttonColor: Record<string, string> = {
   primary: ` bg-bcBluePrimary text-white hover:bg-blue-800 focus:ring-blue-500`,
   secondary: `bg-white text-bcBluePrimary hover:bg-gray-100 focus:ring-blue-500`,
   outline: `bg-white hover:bg-gray-100 focus:ring-blue-500`,
+  danger: `bg-white text-red-600 border-red-600 hover:bg-red-100 focus:ring-red-500`,
 };
 
 export const buttonBase = `h-[38px] inline-flex justify-center items-center rounded border-2 border-bcBluePrimary

--- a/apps/web/src/components/applicant/ApplicantProfile.tsx
+++ b/apps/web/src/components/applicant/ApplicantProfile.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import dayjs from 'dayjs';
+
 import { Access, formatDate, HealthAuthorities } from '@ien/common';
 import { AclMask, Button, DetailsItem } from '@components';
 import { deleteApplicant, updateApplicantActiveFlag } from '@services';
@@ -24,6 +26,7 @@ export const ApplicantProfile = () => {
   const { applicant, fetchApplicant } = useApplicantContext();
   const [activeToggle, setActiveToggle] = useState(true);
   const [deleteApplicantOpen, setDeleteApplicantOpen] = useState(false);
+  const isApplicantDeleted = !!applicant?.deleted_date;
 
   const handleChange = async (flag: boolean) => {
     const updatedApplicant = await updateApplicantActiveFlag(applicant.id, flag);
@@ -59,7 +62,11 @@ export const ApplicantProfile = () => {
           <section>
             <Dialog open={deleteApplicantOpen} onOpenChange={setDeleteApplicantOpen}>
               <DialogTrigger asChild>
-                <Button variant='danger' onClick={() => setDeleteApplicantOpen(true)}>
+                <Button
+                  variant='danger'
+                  onClick={() => setDeleteApplicantOpen(true)}
+                  disabled={isApplicantDeleted}
+                >
                   Delete
                 </Button>
               </DialogTrigger>
@@ -145,6 +152,13 @@ export const ApplicantProfile = () => {
             <DetailsItem title='Pathway' text={applicant?.pathway.name} span={6} />
           )}
           <DetailsItem title='End of Journey' text={applicant?.end_of_journey as string} span={6} />
+          {isApplicantDeleted && (
+            <DetailsItem
+              title='Deleted Date'
+              text={dayjs(applicant?.deleted_date).format('YYYY-MM-DD')}
+              span={6}
+            />
+          )}
         </div>
       </div>
     </>

--- a/apps/web/src/components/applicant/ApplicantProfile.tsx
+++ b/apps/web/src/components/applicant/ApplicantProfile.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Access, formatDate, HealthAuthorities } from '@ien/common';
-import { AclMask, DetailsItem } from '@components';
-import { updateApplicantActiveFlag } from '@services';
+import { AclMask, Button, DetailsItem } from '@components';
+import { deleteApplicant, updateApplicantActiveFlag } from '@services';
 import { useApplicantContext } from './ApplicantContext';
 import { convertCountryCode } from '../../services/convert-country-code';
 import { DetailsHeader } from '../DetailsHeader';
@@ -10,11 +10,20 @@ import { RecruiterAssignment } from './RecruiterAssignment';
 import { ToggleSwitch } from '../ToggleSwitch';
 import { useAuthContext } from '../AuthContexts';
 import { getApplicantEducations } from '../../utils/applicant-utils';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 
 export const ApplicantProfile = () => {
   const { authUser } = useAuthContext();
   const { applicant, fetchApplicant } = useApplicantContext();
   const [activeToggle, setActiveToggle] = useState(true);
+  const [deleteApplicantOpen, setDeleteApplicantOpen] = useState(false);
 
   const handleChange = async (flag: boolean) => {
     const updatedApplicant = await updateApplicantActiveFlag(applicant.id, flag);
@@ -22,6 +31,12 @@ export const ApplicantProfile = () => {
     if (updatedApplicant) {
       fetchApplicant();
     }
+  };
+
+  const handleDeleteApplicant = async () => {
+    await deleteApplicant(applicant.id);
+    fetchApplicant();
+    setDeleteApplicantOpen(false);
   };
 
   useEffect(() => {
@@ -39,6 +54,39 @@ export const ApplicantProfile = () => {
         <p className='text-bcGray text-sm pt-1 pb-4'>
           Last Updated: {formatDate(applicant?.updated_date)}
         </p>
+        {/* Delete Applicant */}
+        <AclMask acl={[Access.ADMIN]}>
+          <section>
+            <Dialog open={deleteApplicantOpen} onOpenChange={setDeleteApplicantOpen}>
+              <DialogTrigger asChild>
+                <Button variant='danger' onClick={() => setDeleteApplicantOpen(true)}>
+                  Delete
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>Are you sure you want to delete this applicant?</DialogHeader>
+                <h1 className='font-bold text-xl py-4'>
+                  {applicant?.name} #{(applicant?.ats1_id || applicant?.id || 'NA').substring(0, 8)}
+                </h1>
+                <DialogFooter className='sm:justify-start md:justify-around gap-2'>
+                  <DialogClose asChild>
+                    <Button variant='outline' forModal={true} type='button'>
+                      Cancel
+                    </Button>
+                  </DialogClose>
+                  <Button
+                    variant='primary'
+                    forModal={true}
+                    type='button'
+                    onClick={handleDeleteApplicant}
+                  >
+                    Confirm
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </section>
+        </AclMask>
         <AclMask authorities={HealthAuthorities}>
           <div className='text-bcGray text-sm pt-1 pb-4 flex items-center' data-cy='active-toggle'>
             <span className='mr-2 font-bold' data-cy='active-text'>

--- a/apps/web/src/services/applicant.ts
+++ b/apps/web/src/services/applicant.ts
@@ -60,6 +60,18 @@ export const deleteApplicantStatus = async (
   }
 };
 
+/**
+ * Delete applicant (scramble PII)
+ * @param id
+ */
+export const deleteApplicant = async (id: string): Promise<void> => {
+  try {
+    await axios.delete(`/ien/${id}`);
+  } catch (e) {
+    notifyError(e as AxiosError);
+  }
+};
+
 // currently unused
 export const updateApplicant = async (id: string, applicant: IENApplicantCreateUpdateDTO) => {
   return axios.patch(`/ien/${id}`, applicant);

--- a/packages/common/src/ro/applicant.ro.ts
+++ b/packages/common/src/ro/applicant.ro.ts
@@ -39,6 +39,8 @@ export interface ApplicantRO {
   end_of_journey?: END_OF_JOURNEY_FLAG | null;
   created_date?: Date;
   updated_date?: Date;
+  deleted_date?: Date | null;
+  deleted_by?: EmployeeRO | null;
 }
 
 export interface ApplicantJobRO {


### PR DESCRIPTION
- Added new columns to the `ien_applicants` table:
  - `deleted_by_id` (UUID, nullable)
  - `deleted_date` (timestamp, nullable)
  - `backup` (JSONB, nullable, default: null)

- Implemented data deletion in the backend, including functionality to scramble personally identifiable information (PII).
- Introduced a deletion date and corresponding button to the frontend interface.
- Added `subscribers` to prevent ATS update the scramble info if applicant was deleted

## Screenshots

- Before Deletion
![CleanShot 2025-01-17 at 10 39 02@2x](https://github.com/user-attachments/assets/08767625-40bf-4174-81ff-af8916f5b868)

- Deleting
![CleanShot 2025-01-17 at 10 39 39@2x](https://github.com/user-attachments/assets/c4cc8121-491f-4c0f-b065-070aeaa0ad1c)

- After Deletion
![CleanShot 2025-01-17 at 10 40 16@2x](https://github.com/user-attachments/assets/be28b509-6d67-4145-bf16-a6c2d5bfd4bd)
