### PR TITLE
JSU-408: Fixing "Cannot delete property '0' of [object Uint8Array]" issue on AWS due to AWS considering int[] as Uint8Array(file data)

### DIFF
--- a/apps/api/src/applicant/ienapplicant.controller.ts
+++ b/apps/api/src/applicant/ienapplicant.controller.ts
@@ -393,7 +393,7 @@ export class IENApplicantController {
     if (e instanceof NotFoundException) {
       return e;
     } else if (e instanceof QueryFailedError) {
-      if (e.message.indexOf('duplicate') !== -1) {
+      if (e.message.includes('duplicate')) {
         return new BadRequestException(`Duplicate milestone with same date found!`);
       }
       throw new BadRequestException(e.message);

--- a/apps/api/src/applicant/ienapplicant.controller.ts
+++ b/apps/api/src/applicant/ienapplicant.controller.ts
@@ -19,6 +19,8 @@ import {
   Req,
   UseGuards,
   UseInterceptors,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { QueryFailedError } from 'typeorm';
@@ -264,6 +266,7 @@ export class IENApplicantController {
   })
   @UseInterceptors(ClassSerializerInterceptor)
   @AllowAccess(Access.APPLICANT_WRITE)
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: false }))
   @Post('/:id/job')
   async addApplicantJob(
     @Req() req: RequestObj,

--- a/apps/api/test/fixture/ien.ts
+++ b/apps/api/test/fixture/ien.ts
@@ -14,6 +14,7 @@ export const applicant = { id: validApplicant.applicant_id };
 export const addJob = {
   ha_pcn: '6ad69443-e3a8-3cbc-8cc9-3a05e5b771e4',
   job_id: 'JOB11',
+  job_location: [1],
 };
 
 export const invalidMilestoneToUpdate = { id: '08ff7e3f-3148-43d3-9740-5a255aa0d5ff' };


### PR DESCRIPTION
- The error occurs because in AWS Lambda environment, certain array data gets treated as a Uint8Array rather than a regular JavaScript array. When the global ValidationPipe with [whitelist: true] tries to process this data, it attempts to delete properties from the Uint8Array, which is not allowed since Uint8Array indexed properties are immutable.
- Adding job_location to e2e test
- Updating indexOf() to includes() as per SonarQube suggestion