### PR TITLE
Adding a custom validation pipe to handle int arrays being read as UInt8 Binary Data.

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,7 +46,7 @@
     "class-transformer": "0.5.1",
     "csv-stringify": "6.0.4",
     "dotenv": "10.0.0",
-    "express": "4.19.2",
+    "express": "5.1.0",
     "handlebars": "4.7.7",
     "js-yaml": "4.1.0",
     "jsonwebtoken": ">=9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,7 +2235,7 @@ __metadata:
     csv-stringify: "npm:6.0.4"
     dotenv: "npm:10.0.0"
     eslint: "npm:8.57.0"
-    express: "npm:4.19.2"
+    express: "npm:5.1.0"
     handlebars: "npm:4.7.7"
     jest: "npm:29.7.0"
     js-yaml: "npm:4.1.0"


### PR DESCRIPTION
Adding a special SafeValidationPipe that detects cases where the data incoming is being read as UInt8. And clean the data to stop the validation error.

This is a blind fix since issue cannot be reproduced locally.