### PR TITLE
chore: add logging for the Node.js runtime version

### DIFF
--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -53,6 +53,7 @@ export class AdminService {
   }
 
   async getUserGuides(): Promise<UserGuide[]> {
+    this.logger.log(`node-version for debugging: ${process.version}`);
     if (!this.s3) {
       //throw new InternalServerErrorException('the feature is disabled');
       return [];

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,7 @@
 import { createNestApp } from './app.config';
 
 async function bootstrap() {
+  console.log(`node-version: ${process.version}`);
   const { app } = await createNestApp();
   app.enableCors({
     origin: process.env.ENV_NAME === 'dev' ? '*' : true,

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,0 +1,13 @@
+// Instrumentation module for web application
+// Read https://nextjs.org/docs/pages/guides/instrumentation for more details
+// The register function is called at applications startup
+
+export function register() {
+    console.log('Instrumentation registered:');
+
+    if (process.release?.name === 'node') {
+        console.log(`Node.js version: ${process.version}`);
+    } else {
+        console.log(`Runtime other than Node.js detected: ${process.release?.name || 'unknown'}`);
+    }
+}


### PR DESCRIPTION
- add logging at api startup and on the /user-guides api end point
- add logging to front end Next.js application on startup

@chloe-yuu please let me know your thoughts on this. I tried to add logging the version when you visit a particular page on the frontend but found the only portion that worked was in `_app.tsx` which caused it to be logged excessively.